### PR TITLE
test: add a temporary version of must.have.members

### DIFF
--- a/test/common.js
+++ b/test/common.js
@@ -1,6 +1,7 @@
 /*jshint latedef:nofunc */
 'use strict';
 var generators = require('yeoman-generator');
+var must = require('must');
 
 exports.createGenerator = createGenerator;
 
@@ -16,4 +17,14 @@ function createGenerator(name, path, deps, args, opts) {
   env.register(path, name);
 
   return env.create(name, { arguments: args || [], options: opts || {} });
+}
+
+// temporary workaround until moll/js-must#16 is released
+if (!must.prototype.members) {
+  must.prototype.members = function members(ary) {
+    var self = this;
+    ary.forEach(function(key) {
+      self.include(key);
+    });
+  };
 }


### PR DESCRIPTION
The proper implementation will be available when the pull request
moll/js-must#16 is merged and released.

/cc @rmg 
