### PR TITLE
package: fixate loopback-workspace version

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "async": "^0.9.0",
     "chalk": "^0.4.0",
     "debug": "^1.0.2",
-    "loopback-workspace": "strongloop/loopback-workspace#3.0",
+    "loopback-workspace": "strongloop/loopback-workspace#f17e652f",
     "yeoman-generator": "^0.16.0",
     "yosay": "^0.1.0"
   },


### PR DESCRIPTION
Use a commit id instead of 3.0 as the version to use. This prevents
`npm install` from pulling backwards-incompatible changes that are
coming to the 3.0 branch.
