### PR TITLE
property: fix array type

### DIFF
--- a/property/index.js
+++ b/property/index.js
@@ -110,7 +110,7 @@ module.exports = yeoman.generators.Base.extend({
       this.name = answers.name || this.name;
       if (answers.type === 'array') {
         var itemType =  answers.customItemType || answers.itemType;
-        this.type = itemType ? '[' + itemType + ']' : 'array';
+        this.type = itemType ? [itemType] : 'array';
       } else {
         this.type = answers.customType || answers.type;
       }

--- a/test/property.test.js
+++ b/test/property.test.js
@@ -64,7 +64,7 @@ describe('loopback:property generator', function() {
     propertyGenerator.run({}, function() {
       var definition = readJsonSync('common/models/car.json');
       var prop = definition.properties.list;
-      expect(prop.type).to.equal('[string]');
+      expect(prop.type).to.eql(['string']);
       done();
     });
   });


### PR DESCRIPTION
The correct notation is `['string']` instead of `'[string]'`.

Requires https://github.com/strongloop/loopback-workspace/pull/87.

/to @raymondfeng please review
