### PR TITLE
Improve loopback:relation for custom model name

### DIFF
--- a/relation/index.js
+++ b/relation/index.js
@@ -67,6 +67,11 @@ module.exports = yeoman.generators.Base.extend({
   askForParameters: function() {
     var done = this.async();
 
+    var modelChoices = this.modelNames.concat({
+      name: '(other)',
+      value: null
+    });
+
     var prompts = [
       {
         name: 'type',
@@ -78,14 +83,23 @@ module.exports = yeoman.generators.Base.extend({
         name: 'toModel',
         message: 'Choose a model to create a relationship with:',
         type: 'list',
-        choices: this.modelNames
+        choices: modelChoices
+      },
+      {
+        name: 'customToModel',
+        message: 'Enter the model name:',
+        required: true,
+        validate: validateName,
+        when: function(answers) {
+          return answers.toModel === null;
+        }
       },
       {
         name: 'asPropertyName',
         message: 'Enter the property name for the relation:',
         required: true,
         default: function(answers) {
-          var m = answers.toModel;
+          var m = answers.customToModel || answers.toModel;
           // Model -> model
           m = inflection.camelize(m, true);
           if (answers.type !== 'belongsTo') {
@@ -106,7 +120,7 @@ module.exports = yeoman.generators.Base.extend({
     ];
     this.prompt(prompts, function(answers) {
       this.type = answers.type;
-      this.toModel = answers.toModel;
+      this.toModel = answers.customToModel || answers.toModel;
       this.asPropertyName = answers.asPropertyName;
       this.foreignKey = answers.foreignKey;
       done();

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -54,6 +54,30 @@ describe('loopback:relation generator', function() {
     });
   });
 
+  it('asks for custom model name', function(done) {
+    var relationGenerator = givenRelationGenerator();
+    helpers.mockPrompt(relationGenerator, {
+      model: 'Car',
+      toModel: null,
+      customToModel: 'Part',
+      asPropertyName: 'parts',
+      foreignKey: 'customKey',
+      type: 'hasMany'
+    });
+
+    relationGenerator.run({}, function() {
+      var definition = readJsonSync('common/models/car.json');
+      var relations = definition.relations || {};
+      expect(relations).to.have.property('parts');
+      expect(relations.parts).to.eql({
+        type: 'hasMany',
+        foreignKey: 'customKey',
+        model: 'Part'
+      });
+      done();
+    });
+  });
+
   // requires generator-yeoman v0.17
   it.skip('provides default property name based on target model for belongsTo',
     function(done) {


### PR DESCRIPTION
Add an `other` option to model names list, if this option is
selected, prompt user to type a model name.

Close https://github.com/strongloop/generator-loopback/issues/35

Signed-off-by: Clark Wang clark.wangs@gmail.com
