### PR TITLE
Create ACLs in series

### DIFF
--- a/acl/index.js
+++ b/acl/index.js
@@ -153,7 +153,7 @@ module.exports = yeoman.generators.Base.extend({
       }
 
       var firstError = true;
-      async.each(models, function(model, cb) {
+      async.eachSeries(models, function(model, cb) {
         model.accessControls.create(aclDef, function(err) {
           if (err && firstError) {
             helpers.reportValidationError(err);


### PR DESCRIPTION
Creating ACLs in parallel fails in the tests but actually creates the ACLs from the command line. This patch changes the ACL creation to be in serial and passes the test. I haven't looked into exactly why this is... Perhaps @bajtos has some ideas.

/to @raymondfeng 
/cc @bajtos 
