### PR TITLE
Allow custom roles to be specified

### DIFF
--- a/acl/index.js
+++ b/acl/index.js
@@ -118,7 +118,15 @@ module.exports = yeoman.generators.Base.extend({
         message: 'Select the role',
         type: 'list',
         default: '$everyone',
-        choices: this.roleValues,
+        choices: this.roleValues.concat(['other']),
+      },
+      {
+        name: 'customRole',
+        message:
+          'Enter the role name:',
+        when: function(answers) {
+          return answers.role === 'other';
+        }
       },
       {
         name: 'permission',
@@ -132,7 +140,7 @@ module.exports = yeoman.generators.Base.extend({
         property: answers.property,
         accessType: answers.accessType,
         principalType: 'ROLE', // TODO(bajtos) support all principal types
-        principalId: answers.role,
+        principalId: answers.customRole || answers.role,
         permission: answers.permission
       };
       done();

--- a/test/acl.test.js
+++ b/test/acl.test.js
@@ -64,6 +64,31 @@ describe('loopback:acl generator', function() {
     });
   });
 
+  it('adds an entry to models.json for custom role', function(done) {
+    var aclGen = givenAclGenerator();
+    helpers.mockPrompt(aclGen, {
+      model: 'Car',
+      scope: 'all',
+      accessType: '*',
+      role: 'other',
+      customRole: 'myRole',
+      permission: 'DENY'
+    });
+
+    aclGen.run({}, function() {
+      var def = readJsonSync('common/models/car.json');
+      var carAcls = def.acls;
+
+      expect(carAcls).to.eql([{
+        accessType: '*',
+        permission: 'DENY',
+        principalType: 'ROLE',
+        principalId: 'myRole'
+      }]);
+      done();
+    });
+  });
+
   it('adds an entry to all models.json', function(done) {
     var aclGen = givenAclGenerator();
     helpers.mockPrompt(aclGen, {


### PR DESCRIPTION
The PR allows users to specify a custom role name for ACLs.

/to @bajtos 
/cc @ritch 
