### PR TITLE
model: support null data source

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -135,3 +135,14 @@ actions.loadDataSources = function () {
     done();
   });
 };
+
+/**
+ * Modify the list of datasources created by {@link loadDataSources}
+ * and prepend an item for `null` datasource.
+ */
+actions.addNullDataSourceItem = function() {
+  this.dataSources.unshift({
+    name: '(no data-source)',
+    value: null
+  });
+};

--- a/model/index.js
+++ b/model/index.js
@@ -31,6 +31,8 @@ module.exports = yeoman.generators.Base.extend({
 
   loadDataSources: actions.loadDataSources,
 
+  addNullDataSourceItem: actions.addNullDataSourceItem,
+
   askForName: function() {
     var done = this.async();
 


### PR DESCRIPTION
Allow the user to specify that the new model should not be attached to any data source.

See #40.

/to @ritch please review
