### PR TITLE
Rework the prompt for the destination dir

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -55,21 +55,6 @@ module.exports = yeoman.generators.Base.extend({
     });
   },
 
-  askForDestinationDir: actions.askForDestinationDir,
-
-  initWorkspace: actions.initWorkspace,
-
-  detectExistingProject: function() {
-    var cb = this.async();
-    Workspace.isValidDir(function(err) {
-      if (err) {
-        cb();
-      } else {
-        cb(new Error('The generator must be run in an empty directory.'));
-      }
-    });
-  },
-
   loadTemplates: function() {
     var done = this.async();
 
@@ -88,7 +73,12 @@ module.exports = yeoman.generators.Base.extend({
     }.bind(this));
   },
 
-  askForParameters: function() {
+  askForProjectName: function() {
+    if (this.options.nested && this.name) {
+      this.appname = this.name;
+      return;
+    }
+
     var done = this.async();
 
     // https://github.com/strongloop/generator-loopback/issues/38
@@ -105,9 +95,21 @@ module.exports = yeoman.generators.Base.extend({
         default: name,
         validate: validateAppName
       }
-      /*
-       TODO(bajtos) not all templates are projects, some of them are components
-       The only functional project template is 'api-server' at the moment
+    ];
+
+    this.prompt(prompts, function(props) {
+      this.appname = props.appname || this.appname;
+      done();
+    }.bind(this));
+  },
+
+  configureDestinationDir: actions.configureDestinationDir,
+
+  askForTemplate: function() {
+    /*
+     TODO(bajtos) not all templates are projects, some of them are components
+     The only functional project template is 'api-server' at the moment
+    var prompts = [
       {
         name: 'template',
         message: 'What kind of application do you have in mind?',
@@ -115,17 +117,22 @@ module.exports = yeoman.generators.Base.extend({
         default: 'api-server',
         choices: this.templates
       }
-       */
-    ];
+     */
 
-    this.prompt(prompts, function(props) {
-      this.appname = props.appname || this.appname;
-      // TODO(bajtos) see the TODO comment above
-      //this.template = props.template;
-      this.template = 'api-server';
+    this.template = 'api-server';
+  },
 
-      done();
-    }.bind(this));
+  initWorkspace: actions.initWorkspace,
+
+  detectExistingProject: function() {
+    var cb = this.async();
+    Workspace.isValidDir(function(err) {
+      if (err) {
+        cb();
+      } else {
+        cb(new Error('The generator must be run in an empty directory.'));
+      }
+    });
   },
 
   project: function() {

--- a/example/index.js
+++ b/example/index.js
@@ -48,16 +48,22 @@ module.exports = yeoman.generators.Base.extend({
     return !!this.options.l;
   },
 
-  askForDestinationDir: actions.askForDestinationDir,
+  setupProjectName: function() {
+    this.appname = 'loopback-example-app';
+  },
 
-  initWorkspace: actions.initWorkspace,
+  configureDestinationDir: actions.configureDestinationDir,
+
+  updateProjectDir: function() {
+    this.projectDir = this.destinationRoot();
+  },
 
   app: function() {
     this._logPart('Create initial project scaffolding');
     this._runGeneratorWithAnswers(
       'loopback:app',
-      ['loopback-example-app'],
-      { /* no answers */});
+      [this.appname],
+      {});
   },
 
   datasourceGeo: function() {

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -10,23 +10,33 @@ var actions = exports;
 // to a generator instance
 
 /**
- * Ask the user whether he wants to scaffold the app in the current directory
- * or whether a new subdirectory should be created instead.
+ * Decide where to create the project, possibly asking the user,
+ * and set the generator environment so that everything is generated
+ * in the target directory.
  */
-actions.askForDestinationDir = function() {
-  if (this._externalProject) return;
+actions.configureDestinationDir = function() {
+  if (this.options.nested && this.options.projectDir) {
+    // no-op when called from `yo loopback:example`
+    return;
+  }
+
+  if (this.appname === path.basename(this.destinationRoot())) {
+    // When the project name is the same as the current directory,
+    // we are assuming the user has already created the project dir
+    return;
+  }
 
   var done = this.async();
   this.prompt([
     {
       name: 'dir',
-      message: 'Enter a directory name where to create the project:',
-      default: '.'
+      message: 'Enter name of the directory to contain the project:',
+      default: this.appname
     }
   ], function(answers) {
     var dir = answers.dir;
     if (!dir || dir === '.') return done();
-    this.dir = dir;
+
     var root = path.join(this.destinationRoot(), dir);
     if (!fs.existsSync(root)) {
       this.log.create(dir + '/');

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -47,9 +47,9 @@ describe('loopback:app generator', function() {
     var gen = givenAppGenerator();
 
     helpers.mockPrompt(gen, {
-      name: 'test-app',
+      appname: 'test-app',
       template: 'api-server',
-      dir: 'test-app',
+      dir: 'test-dir',
     });
 
     gen.run({}, function() {
@@ -57,7 +57,7 @@ describe('loopback:app generator', function() {
       process.chdir(SANDBOX);
 
       var expectedFiles = EXPECTED_PROJECT_FILES.map(function(f) {
-        return 'test-app/' + f;
+        return 'test-dir/' + f;
       });
       helpers.assertFile(expectedFiles);
       done();


### PR DESCRIPTION
Rework the prompt to improve the user experience.
1. Ask for the application name, propose the 1st argument or cwd as the
   default.
2. If the current dir is the same as the app name, then assume the
   destination dir to be '.' and run the generator.
3. Otherwise ask the user for the target directory, using the project
   name as the default value.

See #56 for more details.

/to @raymondfeng please review
