### PR TITLE
[loopback:swagger] Fix path encoding when it contains brackets

### DIFF
--- a/swagger/spec-loader.js
+++ b/swagger/spec-loader.js
@@ -28,9 +28,10 @@ function buildUrl(base, path) {
 function loadSpec(specUrlStr, log, cb) {
   log(chalk.blue('Loading ' + specUrlStr + '...'));
   var specUrl = url.parse(specUrlStr);
+  specUrl.pathname = encodeURI(specUrl.pathname);
   if (specUrl.protocol === 'http:' || specUrl.protocol === 'https:') {
     var options = {
-      url: specUrl.href,
+      url: url.format(specUrl),
       headers: {
         'Accept': 'application/json'
       }


### PR DESCRIPTION
Files (like swagger 1.0 JSON descriptors) which are on a path containing "{" or "}" in their name are not correctly encoded. They should be encoded to %7B and %7D accordingly to correctly follow URI standards. Tomcat currently throws an 500 HTTP code if receiving not correctl encoded URIs.
