### PR TITLE
Drop `must`, use `chai` instead

### DIFF
--- a/package.json
+++ b/package.json
@@ -38,10 +38,10 @@
     "yosay": "^0.3.0"
   },
   "devDependencies": {
+    "chai": "^1.10.0",
     "fs-extra": "^0.10.0",
     "jshint": "^2.5",
     "mocha": "^1.18.2",
-    "must": "^0.12.0",
     "strong-cached-install": "^1.1.0"
   }
 }

--- a/test/acl.test.js
+++ b/test/acl.test.js
@@ -5,7 +5,7 @@ var helpers = require('yeoman-generator').test;
 var wsModels = require('loopback-workspace').models;
 var SANDBOX =  path.resolve(__dirname, 'sandbox');
 var fs = require('fs');
-var expect = require('must');
+var expect = require('chai').expect;
 var common = require('./common');
 
 describe('loopback:acl generator', function() {

--- a/test/common.js
+++ b/test/common.js
@@ -5,7 +5,6 @@ var path = require('path');
 var generators = require('yeoman-generator');
 var workspace = require('loopback-workspace');
 var Workspace = workspace.models.Workspace;
-var must = require('must');
 
 exports.createGenerator = createGenerator;
 
@@ -21,16 +20,6 @@ function createGenerator(name, path, deps, args, opts) {
   env.register(path, name);
 
   return env.create(name, { arguments: args || [], options: opts || {} });
-}
-
-// temporary workaround until moll/js-must#16 is released
-if (!must.prototype.members) {
-  must.prototype.members = function members(ary) {
-    var self = this;
-    ary.forEach(function(key) {
-      self.include(key);
-    });
-  };
 }
 
 exports.createDummyProject = function(dir, name, done) {

--- a/test/datasource.test.js
+++ b/test/datasource.test.js
@@ -4,7 +4,7 @@ var path = require('path');
 var helpers = require('yeoman-generator').test;
 var SANDBOX =  path.resolve(__dirname, 'sandbox');
 var fs = require('fs');
-var expect = require('must');
+var expect = require('chai').expect;
 var common = require('./common');
 
 describe('loopback:datasource generator', function() {

--- a/test/example.test.js
+++ b/test/example.test.js
@@ -6,7 +6,7 @@ var helpers = require('yeoman-generator').test;
 var SANDBOX = path.resolve(__dirname, 'sandbox');
 var common = require('./common');
 var wsModels = require('loopback-workspace').models;
-var expect = require('must');
+var expect = require('chai').expect;
 
 describe('loopback:example generator', function() {
   this.timeout(10000);
@@ -35,7 +35,7 @@ describe('loopback:example generator', function() {
       wsModels.ModelDefinition.find(function(err, list) {
         if (err) return done(err);
         var names = list.map(function(m) { return m.name; });
-        expect(names).to.be.permutationOf([
+        expect(names).to.have.members([
           'Car',
           'Customer',
           'Inventory',

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -3,92 +3,66 @@
 var helpers = require('../lib/helpers');
 var validateAppName = helpers.validateAppName;
 var validateName = helpers.validateName;
-require('must');
+require('chai').should();
+var expect = require('chai').expect;
 
 describe('helpers', function() {
   describe('validateAppName()', function() {
     it('should accept good names', function() {
-      var result = validateAppName('app');
-      result.must.be.true();
-
-      result = validateAppName('app1');
-      result.must.be.true();
-
-      result = validateAppName('my_app');
-      result.must.be.true();
-
-      result = validateAppName('my-app');
-      result.must.be.true();
-
-      result = validateAppName('my.app');
-      result.must.be.true();
+      testValidationAcceptsValue(validateAppName, 'app');
+      testValidationAcceptsValue(validateAppName, 'app1');
+      testValidationAcceptsValue(validateAppName, 'my_app');
+      testValidationAcceptsValue(validateAppName, 'my-app');
+      testValidationAcceptsValue(validateAppName, 'my.app');
     });
 
     it('should report errors for a name starting with .', function() {
-      var result = validateAppName('.app');
-      result.must.be.string();
+      testValidationRejectsValue(validateAppName, '.app');
     });
 
     it('should report errors for a name containing special chars', function () {
-      var result = validateAppName('my app');
-      result.must.be.string();
-      result = validateAppName('my/app');
-      result.must.be.string();
-      result = validateAppName('my@app');
-      result.must.be.string();
-      result = validateAppName('my+app');
-      result.must.be.string();
-      result = validateAppName('my%app');
-      result.must.be.string();
-      result = validateAppName('my:app');
-      result.must.be.string();
+      testValidationRejectsValue(validateAppName, 'my app');
+      testValidationRejectsValue(validateAppName, 'my/app');
+      testValidationRejectsValue(validateAppName, 'my@app');
+      testValidationRejectsValue(validateAppName, 'my+app');
+      testValidationRejectsValue(validateAppName, 'my%app');
+      testValidationRejectsValue(validateAppName, 'my:app');
     });
 
     it('should report errors for a name as node_modules/favicon.ico',
       function () {
-        var result = validateAppName('node_modules');
-        result.must.be.string();
-        result = validateAppName('Node_Modules');
-        result.must.be.string();
-        result = validateAppName('favicon.ico');
-        result.must.be.string();
-        result = validateAppName('favicon.ICO');
-        result.must.be.string();
+        testValidationRejectsValue(validateAppName, 'node_modules');
+        testValidationRejectsValue(validateAppName, 'Node_Modules');
+        testValidationRejectsValue(validateAppName, 'favicon.ico');
+        testValidationRejectsValue(validateAppName, 'favicon.ICO');
       });
 
   });
 
   describe('validateName()', function() {
     it('should accept good names', function() {
-      var result = validateName('prop');
-      result.must.be.true();
-
-      result = validateName('prop1');
-      result.must.be.true();
-
-      result = validateName('my_prop');
-      result.must.be.true();
-
-      result = validateName('my-prop');
-      result.must.be.true();
+      testValidationAcceptsValue(validateName, 'prop');
+      testValidationAcceptsValue(validateName, 'prop1');
+      testValidationAcceptsValue(validateName, 'my_prop');
+      testValidationAcceptsValue(validateName, 'my-prop');
     });
 
     it('should report errors for a name containing special chars', function() {
-      var result = validateName('my prop');
-      result.must.be.string();
-      result = validateName('my/prop');
-      result.must.be.string();
-      result = validateName('my@prop');
-      result.must.be.string();
-      result = validateName('my+prop');
-      result.must.be.string();
-      result = validateName('my%prop');
-      result.must.be.string();
-      result = validateName('my:prop');
-      result.must.be.string();
-      result = validateName('m.prop');
-      result.must.be.string();
+      testValidationRejectsValue(validateName, 'my prop');
+      testValidationRejectsValue(validateName, 'my/prop');
+      testValidationRejectsValue(validateName, 'my@prop');
+      testValidationRejectsValue(validateName, 'my+prop');
+      testValidationRejectsValue(validateName, 'my%prop');
+      testValidationRejectsValue(validateName, 'my:prop');
+      testValidationRejectsValue(validateName, 'm.prop');
     });
   });
-
 });
+
+function testValidationAcceptsValue(validationFn, value) {
+  expect(validationFn(value), value).to.be.true();
+}
+
+function testValidationRejectsValue(validationFn, value) {
+  expect(validationFn(value), value).to.be.a('string');
+}

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -4,7 +4,7 @@ var path = require('path');
 var helpers = require('yeoman-generator').test;
 var SANDBOX =  path.resolve(__dirname, 'sandbox');
 var fs = require('fs');
-var expect = require('must');
+var expect = require('chai').expect;
 var wsModels = require('loopback-workspace').models;
 var common = require('./common');
 

--- a/test/property.test.js
+++ b/test/property.test.js
@@ -5,7 +5,7 @@ var helpers = require('yeoman-generator').test;
 var wsModels = require('loopback-workspace').models;
 var SANDBOX =  path.resolve(__dirname, 'sandbox');
 var fs = require('fs');
-var expect = require('must');
+var expect = require('chai').expect;
 var common = require('./common');
 
 describe('loopback:property generator', function() {

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -5,7 +5,7 @@ var helpers = require('yeoman-generator').test;
 var wsModels = require('loopback-workspace').models;
 var SANDBOX =  path.resolve(__dirname, 'sandbox');
 var fs = require('fs');
-var expect = require('must');
+var expect = require('chai').expect;
 var common = require('./common');
 
 describe('loopback:relation generator', function() {

--- a/test/swagger.test.js
+++ b/test/swagger.test.js
@@ -5,7 +5,7 @@ var helpers = require('yeoman-generator').test;
 var SANDBOX = path.resolve(__dirname, 'sandbox');
 var path = require('path');
 var fs = require('fs');
-var expect = require('must');
+var expect = require('chai').expect;
 var common = require('./common');
 
 describe('loopback:swagger generator', function () {


### PR DESCRIPTION
Since `chai` added support for chainable no-op functions (e.g. `true()`) in v1.10.0, there is no longer need to use `must`.

Close #70.
