### PR TITLE
example: use the new middleware registration

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -401,28 +401,19 @@ module.exports = yeoman.generators.Base.extend({
     this.conflicter.resolve(this.async());
   },
 
-  removeStatus: function() {
+  replaceStatusWithWebsite: function() {
+    var middlewareJSon = 'server/middleware.json';
+    var middleware = JSON.parse(this.readFileAsString(middlewareJSon));
+
     this._logPart('Remove status handler from "/"');
-    fs.unlinkSync(path.join(this.projectDir, 'server/boot/root.js'));
-  },
+    delete middleware.routes['loopback#status'];
 
-  mountWebsite: function() {
-    this._logPart('Mount `website` at "/"');
+    this._logPart('Mount `client` at "/"');
+    middleware.routes['loopback#static'] = { params: '#!../client' };
 
-    var SNIPPET =
-      'var websitePath = require(\'path\').' +
-      'resolve(__dirname, \'../client\');\n' +
-      'app.use(loopback.static(websitePath));';
-
-    var serverJs = 'server/server.js';
-    var script = this.readFileAsString(serverJs);
-
-    script = script.replace(
-      /(app\.use\(loopback\.static\(.*)$/m,
-        '$1\n' + SNIPPET);
-
-    this.writeFileFromString(script, serverJs);
-
+    this.writeFileFromString(
+      JSON.stringify(middleware, null, 2),
+      middlewareJSon);
   },
 
   installDeps: actions.installDeps,

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "debug": "^1.0.2",
     "inflection": "^1.3.8",
     "loopback-swagger": "^1.0.0",
-    "loopback-workspace": "^3.2.0",
+    "loopback-workspace": "^3.6.0",
     "request": "~2.40.0",
     "yeoman-generator": "^0.16.0",
     "yosay": "^0.3.0"


### PR DESCRIPTION
Rework the example generator to use `server/middleware.json` for registering static file middleware.

A part of strongloop/loopback-workspace#167

/to @raymondfeng please review
