### PR TITLE
Fix bad path expansion in loopback:example

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -406,7 +406,7 @@ module.exports = yeoman.generators.Base.extend({
     delete middleware.routes['loopback#status'];
 
     this._logPart('Mount `client` at "/"');
-    middleware.routes['loopback#static'] = { params: '#!../client' };
+    middleware.routes['loopback#static'] = { params: '$!../client' };
 
     this.writeFileFromString(
       JSON.stringify(middleware, null, 2),


### PR DESCRIPTION
loopback-boot uses $! for expansion, not #!

In other words, anyone who runs `slc loopback:example` starting last week and up until this PR is merged is going to get a broken loopback-example-app :-(
