### PR TITLE
example: support both flavours of status route

### DIFF
--- a/example/index.js
+++ b/example/index.js
@@ -403,7 +403,14 @@ module.exports = yeoman.generators.Base.extend({
     var middleware = JSON.parse(this.readFileAsString(middlewareJSon));
 
     this._logPart('Remove status handler from "/"');
+    // loopback-workspace 3.6.0-3.6.5
     delete middleware.routes['loopback#status'];
+
+    // loopback-workspace <3.6.0 and 3.6.6+
+    var rootJs = path.join(this.projectDir, 'server/boot/root.js');
+    if (fs.existsSync(rootJs)) {
+      fs.unlinkSync(rootJs);
+    }
 
     this._logPart('Mount `client` at "/"');
     middleware.routes['loopback#static'] = { params: '#!../client' };


### PR DESCRIPTION
The project template in loopback-workspace 3.6.0-3.6.5 incorrectly
registers `loopback.status()` middleware via `middleware.json`.
Versions until 3.5.x and after 3.6.6 register the status route
from a boot script.

This patch modifies the example generator to support both flavours.

See also https://github.com/strongloop/loopback-workspace/pull/182 and #80

/to @raymondfeng or @ritch please review