### PR TITLE
Fix tests failing on the latest yeoman-generator

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "loopback-swagger": "^2.0.0",
     "loopback-workspace": "^3.6.0",
     "request": "^2.47.0",
-    "yeoman-generator": "^0.18.1",
+    "yeoman-generator": "^0.18.7",
     "yosay": "^1.0.0"
   },
   "devDependencies": {

--- a/test/acl.test.js
+++ b/test/acl.test.js
@@ -50,7 +50,7 @@ describe('loopback:acl generator', function() {
       permission: 'AUDIT'
     });
 
-    aclGen.run({}, function() {
+    aclGen.run(function() {
       var def = readJsonSync('common/models/car.json');
       var carAcls = def.acls;
 
@@ -74,7 +74,7 @@ describe('loopback:acl generator', function() {
       permission: 'AUDIT'
     });
 
-    aclGen.run({}, function() {
+    aclGen.run(function() {
       var def = readJsonSync('common/models/car.json');
       var carAcls = def.acls;
 
@@ -100,7 +100,7 @@ describe('loopback:acl generator', function() {
       permission: 'DENY'
     });
 
-    aclGen.run({}, function() {
+    aclGen.run(function() {
       var def = readJsonSync('common/models/car.json');
       var carAcls = def.acls;
 
@@ -123,7 +123,7 @@ describe('loopback:acl generator', function() {
       permission: 'ALLOW'
     });
 
-    aclGen.run({}, function() {
+    aclGen.run(function() {
       var def = readJsonSync('common/models/car.json');
       var carAcls = def.acls;
 

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -37,7 +37,7 @@ describe('loopback:app generator', function() {
     });
 
     gen.options['skip-install'] = true;
-    gen.run({}, function () {
+    gen.run(function () {
       helpers.assertFile(EXPECTED_PROJECT_FILES);
       done();
     });
@@ -52,7 +52,7 @@ describe('loopback:app generator', function() {
       dir: 'test-dir',
     });
 
-    gen.run({}, function() {
+    gen.run(function() {
       // generator calls `chdir` on change of the destination root
       process.chdir(SANDBOX);
 
@@ -100,7 +100,7 @@ describe('loopback:app generator', function() {
         dir: '.'
       });
 
-      gen.run({}, function() {
+      gen.run(function() {
         // generator calls `chdir` on change of the destination root
         process.chdir(SANDBOX);
 

--- a/test/datasource.test.js
+++ b/test/datasource.test.js
@@ -28,7 +28,7 @@ describe('loopback:datasource generator', function() {
     });
 
     var builtinSources = Object.keys(readDataSourcesJsonSync('server'));
-    modelGen.run({}, function() {
+    modelGen.run(function() {
       var newSources = Object.keys(readDataSourcesJsonSync('server'));
       var expectedSources = builtinSources.concat(['crm']);
       expect(newSources).to.have.members(expectedSources);

--- a/test/end-to-end/example.e2e.js
+++ b/test/end-to-end/example.e2e.js
@@ -25,7 +25,7 @@ describe('loopback:example generator (end-to-end)', function() {
     helpers.mockPrompt(gen, {
       dir: '.'
     });
-    gen.run({}, done);
+    gen.run(done);
   });
 
   before(function installPackage(done) {

--- a/test/example.test.js
+++ b/test/example.test.js
@@ -23,7 +23,7 @@ describe('loopback:example generator', function() {
         dir: '.'
       });
 
-      gen.run({}, done);
+      gen.run(done);
     });
 
     it('has name "loopback-example-app"', function() {

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -35,7 +35,7 @@ describe('loopback:model generator', function() {
       dataSource: 'db'
     });
 
-    modelGen.run({}, function() {
+    modelGen.run(function() {
       var content = readProductJsonSync();
       expect(content).to.have.property('name', 'Product');
       expect(content).to.not.have.property('public');
@@ -54,7 +54,7 @@ describe('loopback:model generator', function() {
     });
 
     var builtinModels = Object.keys(readModelsJsonSync('server'));
-    modelGen.run({}, function() {
+    modelGen.run(function() {
       var modelConfig = readModelsJsonSync('server');
       var newModels = Object.keys(modelConfig);
       var expectedModels = builtinModels.concat(['Product']);
@@ -75,7 +75,7 @@ describe('loopback:model generator', function() {
       base: 'PersistedModel'
     });
 
-    modelGen.run({}, function() {
+    modelGen.run(function() {
       var product = readProductJsonSync();
       expect(product).to.have.property('base', 'PersistedModel');
       done();
@@ -91,7 +91,7 @@ describe('loopback:model generator', function() {
       customBase: 'CustomModel'
     });
 
-    modelGen.run({}, function() {
+    modelGen.run(function() {
       var product = readProductJsonSync();
       expect(product).to.have.property('base', 'CustomModel');
       done();

--- a/test/property.test.js
+++ b/test/property.test.js
@@ -44,7 +44,7 @@ describe('loopback:property generator', function() {
       required: 'true'
     });
 
-    propertyGenerator.run({}, function() {
+    propertyGenerator.run(function() {
       var definition = readJsonSync('common/models/car.json');
       var props = definition.properties || {};
       expect(props).to.have.property('isPreferred');
@@ -69,7 +69,7 @@ describe('loopback:property generator', function() {
       itemType: 'string'
     });
 
-    propertyGenerator.run({}, function() {
+    propertyGenerator.run(function() {
       var definition = readJsonSync('common/models/car.json');
       var prop = definition.properties.list;
       expect(prop.type).to.eql(['string']);

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -41,7 +41,7 @@ describe('loopback:relation generator', function() {
       type: 'hasMany'
     });
 
-    relationGenerator.run({}, function() {
+    relationGenerator.run(function() {
       var definition = readJsonSync('common/models/car.json');
       var relations = definition.relations || {};
       expect(relations).to.have.property('parts');
@@ -65,7 +65,7 @@ describe('loopback:relation generator', function() {
       type: 'hasMany'
     });
 
-    relationGenerator.run({}, function() {
+    relationGenerator.run(function() {
       var definition = readJsonSync('common/models/car.json');
       var relations = definition.relations || {};
       expect(relations).to.have.property('parts');
@@ -90,7 +90,7 @@ describe('loopback:relation generator', function() {
       throughModel: 'CarPart'
     });
 
-    relationGenerator.run({}, function() {
+    relationGenerator.run(function() {
       var definition = readJsonSync('common/models/car.json');
       var relations = definition.relations || {};
       expect(relations).to.have.property('parts');
@@ -117,7 +117,7 @@ describe('loopback:relation generator', function() {
       customThroughModel: 'CarPart'
     });
 
-    relationGenerator.run({}, function() {
+    relationGenerator.run(function() {
       var definition = readJsonSync('common/models/car.json');
       var relations = definition.relations || {};
       expect(relations).to.have.property('parts');
@@ -140,7 +140,7 @@ describe('loopback:relation generator', function() {
         toModel: 'Part',
         type: 'belongsTo'
       });
-      relationGenerator.run({}, function() {
+      relationGenerator.run(function() {
         var definition = readJsonSync('common/models/car.json');
         var relations = definition.relations || {};
         expect(Object.keys(relations)).to.include('part');
@@ -158,7 +158,7 @@ describe('loopback:relation generator', function() {
         toModel: 'Part',
         type: 'hasMany'
       });
-      relationGenerator.run({}, function() {
+      relationGenerator.run(function() {
         var definition = readJsonSync('common/models/car.json');
         var relations = definition.relations || {};
         expect(Object.keys(relations)).to.include('parts');

--- a/test/swagger.test.js
+++ b/test/swagger.test.js
@@ -30,7 +30,7 @@ describe('loopback:swagger generator', function () {
         dataSource: 'db'
       });
 
-      modelGen.run({}, function () {
+      modelGen.run(function () {
         var content = readModelJsonSync('pet');
         expect(content).to.have.property('name', 'Pet');
         expect(content).to.not.have.property('public');
@@ -59,7 +59,7 @@ describe('loopback:swagger generator', function () {
         dataSource: 'db'
       });
 
-      modelGen.run({}, function () {
+      modelGen.run(function () {
         var content = readModelJsonSync('pet');
         expect(content).to.have.property('name', 'Pet');
         expect(content).to.not.have.property('public');


### PR DESCRIPTION
Use `generator.run(cb)` instead of `generator.run(opts, cb)`, since the latter no longer works.