### PR TITLE
Refactor `injectWorkspaceCopyRecursive`

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -5,6 +5,7 @@ var chalk = require('chalk');
 var workspace = require('loopback-workspace');
 var Workspace = workspace.models.Workspace;
 
+var fs = require('fs');
 var path = require('path');
 
 var actions = require('../lib/actions');
@@ -45,7 +46,11 @@ module.exports = yeoman.generators.Base.extend({
   injectWorkspaceCopyRecursive: function() {
     var originalMethod = Workspace.copyRecursive;
     Workspace.copyRecursive = function(src, dest, cb) {
-      this.directory(src, dest);
+      var isDir = fs.statSync(src).isDirectory();
+      if (isDir)
+        this.directory(src, dest);
+      else
+        this.copy(src, dest);
       process.nextTick(cb);
     }.bind(this);
 

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "debug": "^2.1.0",
     "inflection": "^1.3.8",
     "loopback-swagger": "^2.0.0",
-    "loopback-workspace": "^3.6.0",
+    "loopback-workspace": "^3.7.1",
     "request": "^2.47.0",
     "yeoman-generator": "^0.18.7",
     "yosay": "^1.0.0"

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -17,6 +17,7 @@ describe('loopback:app generator', function() {
   // we don't have to test it again.
 
   var EXPECTED_PROJECT_FILES = [
+    '.gitignore',
     'package.json',
 
     'server/config.json',


### PR DESCRIPTION
Use native `this.copy` when source file is not a directory. This allows us to
copy `gitignore` to `.gitignore` when scaffolding new projects.