### PR TITLE
Use async features in example generator

### DIFF
--- a/example/templates/server/boot/create-sample-data.js
+++ b/example/templates/server/boot/create-sample-data.js
@@ -1,18 +1,13 @@
 var importer = require('../sample-data/import');
 
-module.exports = function(app) {
+module.exports = function(app, cb) {
   if (app.dataSources.db.name !== 'Memory') return;
 
-  console.error('Started the import of sample data.');
-  app.importing = true;
+  console.log('Started the import of sample data.');
 
   importer(app, function(err) {
-    delete app.importing;
-    if (err) {
-      console.error('Cannot import sample data - ', err);
-    } else {
-      console.error('Sample data was imported.');
-    }
-    app.emit('import done', err);
+    if (err) return cb(err);
+    console.log('Sample data was imported.');
+    cb();
   });
 };

--- a/example/templates/server/sample-data/import.js
+++ b/example/templates/server/sample-data/import.js
@@ -53,10 +53,6 @@ module.exports = function(app, cb) {
   });
 };
 
-if (require.main === module) {
-  // Run the import (server runs it automatically during boot)
-  var app = require('../server');
-  app.on('import done', function(err) {
-    process.exit(err ? 1 : 0);
-  });
-}
+if (require.main === module)
+  // The import runs automatically during the boot process.
+  require('../server');

--- a/example/templates/server/test/rest-api.test.js
+++ b/example/templates/server/test/rest-api.test.js
@@ -8,11 +8,10 @@ var assert = require('assert');
 
 before(function importSampleData(done) {
   this.timeout(50000);
-  if (app.importing) {
-    app.on('import done', done);
-  } else {
+  if (app.booting)
+    app.on('booted', done);
+  else
     done();
-  }
 });
 
 function json(verb, url) {

--- a/package.json
+++ b/package.json
@@ -32,7 +32,7 @@
     "debug": "^2.1.0",
     "inflection": "^1.3.8",
     "loopback-swagger": "^2.0.0",
-    "loopback-workspace": "^3.7.1",
+    "loopback-workspace": "^3.10.0",
     "request": "^2.47.0",
     "yeoman-generator": "^0.18.7",
     "yosay": "^1.0.0"


### PR DESCRIPTION
- Change `app.importing` to `app.booting`
- Use callbacks instead of emitting `import done`
- Replace `import done` event with the `ready` event

Connected to strongloop/generator-loopback#74