### PR TITLE
Create .yo-rc.json when scaffolding new apps

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -154,6 +154,11 @@ module.exports = yeoman.generators.Base.extend({
     this.directory('.', '.');
   },
 
+  generateYoRc: function() {
+    this.log('Generating .yo-rc.json');
+    this.config.save();
+  },
+
   installing: actions.installDeps,
 
   end: function() {

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -5,6 +5,7 @@ var helpers = require('yeoman-generator').test;
 var SANDBOX =  path.resolve(__dirname, 'sandbox');
 var common = require('./common');
 var assert = require('assert');
+var fs = require('fs');
 
 describe('loopback:app generator', function() {
   beforeEach(common.resetWorkspace);
@@ -82,6 +83,16 @@ describe('loopback:app generator', function() {
     var cwdName = 'x@y';
     var expectedAppName = 'x-y';
     testAppNameNormalization(cwdName, expectedAppName, done);
+  });
+
+  it('should create .yo-rc.json', function(done) {
+    var gen = givenAppGenerator();
+    helpers.mockPrompt(gen, {dir: '.'});
+    gen.run(function() {
+      var yoRcPath = path.resolve(SANDBOX, '.yo-rc.json');
+      assert(fs.existsSync(yoRcPath), 'file exists');
+      done();
+    });
   });
 
   function givenAppGenerator(modelArgs) {


### PR DESCRIPTION
Yeoman looks for `.yo-rc.json` (out-of-box) to determine the project root when
executing scripts. This means generators and sub-generator can be run in child
directories (not only from the project root).

Connected to strongloop-internal/scrum-loopback#207