### PR TITLE
Change slc run to slc start in end next steps

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -182,10 +182,7 @@ module.exports = yeoman.generators.Base.extend({
     this.log(chalk.green('    $ slc strongops'));
     this.log();
     this.log('  Run the app');
-    if (cmd === 'yo')
-      this.log(chalk.green('    $ node .'));
-    else
-      this.log(chalk.green('    $ ' + cmd + ' start'));
+    this.log(chalk.green('    $ node .'));
     this.log();
   }
 });

--- a/app/index.js
+++ b/app/index.js
@@ -178,8 +178,8 @@ module.exports = yeoman.generators.Base.extend({
     this.log('  Create a model in your app');
     this.log(chalk.green('    $ ' + cmd + ' loopback:model'));
     this.log();
-    this.log('  Optional: Enable StrongOps monitoring');
-    this.log(chalk.green('    $ slc strongops'));
+    this.log('  Compose your API, run, deploy, profile, and monitor it with Arc');
+    this.log(chalk.green('    $ slc arc'));
     this.log();
     this.log('  Run the app');
     this.log(chalk.green('    $ node .'));

--- a/app/index.js
+++ b/app/index.js
@@ -185,7 +185,7 @@ module.exports = yeoman.generators.Base.extend({
     if (cmd === 'yo')
       this.log(chalk.green('    $ node .'));
     else
-      this.log(chalk.green('    $ ' + cmd + ' run .'));
+      this.log(chalk.green('    $ ' + cmd + ' start'));
     this.log();
   }
 });


### PR DESCRIPTION
Change _Next Steps_ instructions to recommend `slc start` instead of `slc run` in alignment with documentation.

http://docs.strongloop.com/display/NODE/slc+run
http://docs.strongloop.com/display/public/LB/Running+apps+with+slc

Connect to #101
