### PR TITLE
model: Prevent warning about EventEmitter leak

### DIFF
--- a/model/index.js
+++ b/model/index.js
@@ -21,6 +21,11 @@ module.exports = yeoman.generators.Base.extend({
       required: false,
       type: String
     });
+
+    // Prevent "warning: possible EventEmitter memory leak detected"
+    // when adding more than 10 properties
+    // See https://github.com/strongloop/generator-loopback/issues/99
+    this.env.sharedFs.setMaxListeners(256);
   },
 
   help: function() {


### PR DESCRIPTION
Prevent "warning: possible EventEmitter memory leak detected" when adding more than 10 properties. This patch raises the limit to 256.

Fix #99 

/to @raymondfeng please review
/cc @lius