### PR TITLE
Update middleware.test.js to take loopback#rest into consideration

### DIFF
--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -91,7 +91,7 @@ describe('loopback:middleware generator', function() {
         var newSources = Object.keys(
           readMiddlewaresJsonSync('server')['routes:after']);
         var expectedSources = builtinSources.concat(['my-middleware-4']);
-        expect(newSources).to.have.members(expectedSources);
+        expect(expectedSources).to.have.include.members(newSources);
         done();
       });
     });


### PR DESCRIPTION
`loopback#rest` is expected to be present by default because of https://github.com/strongloop/loopback-workspace/pull/230