### PR TITLE
test/middleware: fix failure caused by typo

### DIFF
--- a/package.json
+++ b/package.json
@@ -33,7 +33,7 @@
     "inflection": "^1.7.1",
     "js-yaml": "^3.4.2",
     "loopback-swagger": "^2.0.0",
-    "loopback-workspace": "^3.16.0",
+    "loopback-workspace": "^3.18.0",
     "request": "^2.60.0",
     "yeoman-generator": "^0.20.2",
     "yosay": "^1.0.5"

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -86,7 +86,7 @@ describe('loopback:middleware generator', function() {
       });
 
       var builtinSources = Object.keys(
-        readMiddlewaresJsonSync('server').routes);
+        readMiddlewaresJsonSync('server')['routes:after'] || {});
       modelGen.run(function() {
         var newSources = Object.keys(
           readMiddlewaresJsonSync('server')['routes:after']);


### PR DESCRIPTION
The problem was brought into light by
https://github.com/strongloop/loopback-workspace/pull/230