### PR TITLE
Make sure relation name different from property name

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -60,6 +60,26 @@ exports.validateName = function (name) {
 };
 
 /**
+ * Check if relation has a different name from properties
+ * @param {Object} modelDefinition The model which has the relation
+ * @param {String} name The user input
+ * @param {Function(String|Boolean)} Callback to receive the check result.
+ */
+exports.checkRelationName = function (modelDefinition, name, callback) {
+  modelDefinition.properties(function(err, list) {
+    if (err) callback(err);
+    var conflict = list.some(function(property) {
+      return property.name === name;
+    });
+    if (conflict) {
+      callback('Same property name already exists: ' + name);
+    } else {
+      callback(true);
+    }
+  });
+};
+
+/**
  * Get the root command name based on the env var
  * @returns {string}
  */

--- a/relation/index.js
+++ b/relation/index.js
@@ -9,6 +9,7 @@ var ModelRelation = workspace.models.ModelRelation;
 var actions = require('../lib/actions');
 var helpers = require('../lib/helpers');
 var validateName = helpers.validateName;
+var checkRelationName = helpers.checkRelationName;
 
 module.exports = yeoman.generators.Base.extend({
 
@@ -65,6 +66,7 @@ module.exports = yeoman.generators.Base.extend({
   },
 
   askForParameters: function() {
+    var modelDef = this.modelDefinition;
     var done = this.async();
 
     var modelChoices = this.modelNames.concat({
@@ -108,7 +110,11 @@ module.exports = yeoman.generators.Base.extend({
           }
           return m;
         },
-        validate: validateName
+        validate: function(value) {
+          var isValid = validateName(value);
+          if (isValid !== true) return isValid;
+          return checkRelationName(modelDef, value, this.async());
+        }
       },
       {
         name: 'foreignKey',

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -3,6 +3,7 @@
 var helpers = require('../lib/helpers');
 var validateAppName = helpers.validateAppName;
 var validateName = helpers.validateName;
+var checkRelationName = helpers.checkRelationName;
 require('chai').should();
 var expect = require('chai').expect;
 
@@ -57,6 +58,21 @@ describe('helpers', function() {
       testValidationRejectsValue(validateName, 'm.prop');
     });
   });
+
+  // test checkRelationName()
+  describe('checkRelationName()', function() {
+    var sampleModelDefinition = new ModelDefinition([
+      {name: 'name', id: 1},
+      {name: 'city', id: 2}
+    ]);
+    it('should accept names with no conflict', function() {
+      testRelationAcceptsValue(sampleModelDefinition, 'myrelation');
+    });
+
+    it('should report errors for duplicate name', function() {
+      testRelationRejectsValue(sampleModelDefinition, 'city');
+    });
+  });
 });
 
 function testValidationAcceptsValue(validationFn, value) {
@@ -65,4 +81,23 @@ function testValidationAcceptsValue(validationFn, value) {
 
 function testValidationRejectsValue(validationFn, value) {
   expect(validationFn(value), value).to.be.a('string');
+}
+
+function testRelationAcceptsValue(modelDefinition, value) {
+  checkRelationName(modelDefinition, value, function(result) {
+    expect(result, value).to.equal(true);
+  });
+}
+
+function testRelationRejectsValue(modelDefinition, value) {
+  checkRelationName(modelDefinition, value, function(result) {
+    expect(result, value).to.be.a('string');
+  });
+}
+
+function ModelDefinition(propertyList) {
+  this.propertyList = propertyList;
+  this.properties = function(callback) {
+    callback(null, this.propertyList);
+  };
 }


### PR DESCRIPTION
Still work in progress.
Through this pull request I am trying to fix issue 118 (`https://github.com/strongloop/generator-loopback/issues/118`)
Mainly I added a validate function inside prompts to check the name conflict, all these changes happened in /relation/index.js

Fix #118