### PR TITLE
Fix ci timeout error.

### DIFF
--- a/test/help.test.js
+++ b/test/help.test.js
@@ -7,6 +7,8 @@ var helpers = require('yeoman-generator').test;
 var SANDBOX =  path.resolve(__dirname, 'sandbox');
 
 describe('loopback generator help', function () {
+  this.timeout(300000); // 5 minutes
+
   beforeEach(function createSandbox(done) {
     helpers.testDirectory(SANDBOX, done);
   });


### PR DESCRIPTION
  43 passing (51s)
  1 failing

  1) loopback generator help "before each" hook: createSandbox for "print help message with yo by default":
     Error: timeout of 2000ms exceeded. Ensure the done() callback is being called in this test.