### PR TITLE
Prevent constructor to be property name

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -5,6 +5,8 @@ var yeoman = require('yeoman-generator');
 var Workspace = require('loopback-workspace').models.Workspace;
 var ModelProperty = require('loopback-workspace').models.ModelProperty;
 
+var RESERVED_PROPERTY_NAMES = ['constructor'];
+
 exports.reportValidationError = function(err, logFn) {
   if (!err || err.name !== 'ValidationError') {
     return;
@@ -39,6 +41,20 @@ exports.validateAppName = function (name) {
   if(name !== encodeURIComponent(name)) {
     return 'Application name cannot contain special characters escaped by ' +
       'encodeURIComponent: ' + name;
+  }
+  return true;
+};
+
+/**
+ * Validate property name
+ * @param {String} name The user input
+ * @returns {String|Boolean}
+ */
+exports.checkPropertyName = function(name) {
+  var result = exports.validateName(name);
+  if (result !== true) return result;
+  if (RESERVED_PROPERTY_NAMES.indexOf(name) !== -1) {
+    return name + ' is a reserved keyword. Please use another name';
   }
   return true;
 };

--- a/property/index.js
+++ b/property/index.js
@@ -5,6 +5,7 @@ var chalk = require('chalk');
 var actions = require('../lib/actions');
 var helpers = require('../lib/helpers');
 var validateName = helpers.validateName;
+var checkPropertyName = helpers.checkPropertyName;
 var typeChoices = helpers.getTypeChoices();
 
 module.exports = yeoman.generators.Base.extend({
@@ -63,7 +64,7 @@ module.exports = yeoman.generators.Base.extend({
       {
         name: 'name',
         message: 'Enter the property name:',
-        validate: validateName,
+        validate: checkPropertyName,
         when: function() {
           return !this.name && this.name !== 0;
         }.bind(this)

--- a/relation/index.js
+++ b/relation/index.js
@@ -10,6 +10,7 @@ var actions = require('../lib/actions');
 var helpers = require('../lib/helpers');
 var validateName = helpers.validateName;
 var checkRelationName = helpers.checkRelationName;
+var checkPropertyName = helpers.checkPropertyName;
 
 module.exports = yeoman.generators.Base.extend({
 
@@ -111,7 +112,7 @@ module.exports = yeoman.generators.Base.extend({
           return m;
         },
         validate: function(value) {
-          var isValid = validateName(value);
+          var isValid = checkPropertyName(value);
           if (isValid !== true) return isValid;
           return checkRelationName(modelDef, value, this.async());
         }

--- a/remote-method/index.js
+++ b/remote-method/index.js
@@ -7,6 +7,7 @@ var path = require('path');
 var actions = require('../lib/actions');
 var helpers = require('../lib/helpers');
 var validateName = helpers.validateName;
+var checkPropertyName = helpers.checkPropertyName;
 var typeChoices = helpers.getTypeChoices();
 var ModelDefinition = require('loopback-workspace').models.ModelDefinition;
 
@@ -89,7 +90,7 @@ module.exports = yeoman.generators.Base.extend({
         message: 'Enter the remote method name:',
         required: true,
         default: name,
-        validate: validateName
+        validate: checkPropertyName
       },
       {
         name: 'isStatic',


### PR DESCRIPTION
Connect to strongloop-internal/scrum-loopback#642

Hey @bajtos this pr is created for preventing users naming a property as `constructor` in property, relation and remote method generators.
I use an array to contain reserved keywords in case we have more in the future, but now it only has `constructor`. 
Could you review it? Thanks!