### PR TITLE
Import `generator#invoke()` directly

### DIFF
--- a/model/index.js
+++ b/model/index.js
@@ -30,7 +30,7 @@ module.exports = yeoman.generators.Base.extend({
     // A workaround to get rid of deprecation notice
     //   "generator#invoke() is deprecated. Use generator#composeWith()"
     // See https://github.com/strongloop/generator-loopback/issues/116
-    this.invoke = require('yeoman-generator/actions/invoke');
+    this.invoke = require('yeoman-generator/lib/actions/invoke');
   },
 
   help: function() {

--- a/model/index.js
+++ b/model/index.js
@@ -26,6 +26,11 @@ module.exports = yeoman.generators.Base.extend({
     // when adding more than 10 properties
     // See https://github.com/strongloop/generator-loopback/issues/99
     this.env.sharedFs.setMaxListeners(256);
+
+    // A workaround to get rid of deprecation notice
+    //   "generator#invoke() is deprecated. Use generator#composeWith()"
+    // See https://github.com/strongloop/generator-loopback/issues/116
+    this.invoke = require('yeoman-generator/actions/invoke');
   },
 
   help: function() {


### PR DESCRIPTION
Import the implementation of `generator#invoke` directly from `generator-yeoman/actions/invoke` to prevent a deprecation warning.

Fix #116

@jannyHou could you please verify that my solution proposed here works for you too?

/to @raymondfeng please review