### PR TITLE
Prompt for Default Value on Property creation

### DIFF
--- a/property/index.js
+++ b/property/index.js
@@ -5,7 +5,6 @@ var chalk = require('chalk');
 var actions = require('../lib/actions');
 var helpers = require('../lib/helpers');
 var validateName = helpers.validateName;
-var checkPropertyName = helpers.checkPropertyName;
 var typeChoices = helpers.getTypeChoices();
 
 module.exports = yeoman.generators.Base.extend({
@@ -64,7 +63,7 @@ module.exports = yeoman.generators.Base.extend({
       {
         name: 'name',
         message: 'Enter the property name:',
-        validate: checkPropertyName,
+        validate: validateName,
         when: function() {
           return !this.name && this.name !== 0;
         }.bind(this)
@@ -106,6 +105,11 @@ module.exports = yeoman.generators.Base.extend({
         message: 'Required?',
         type: 'confirm',
         default: false
+      },
+      {
+         name: 'defaultValue',
+         message: 'Default value[leave blank for none]:',
+         default: null
       }
     ];
     this.prompt(prompts, function(answers) {
@@ -117,6 +121,7 @@ module.exports = yeoman.generators.Base.extend({
         this.type = answers.customType || answers.type;
       }
       this.required = answers.required;
+      this.defaultValue = answers.defaultValue;
       done();
     }.bind(this));
   },
@@ -129,6 +134,21 @@ module.exports = yeoman.generators.Base.extend({
     };
     if (this.required) {
       def.required = true;
+    }
+    if (this.defaultValue) {
+      if (this.type == 'boolean'){
+        if (['true', '1', 't'].indexOf(this.defaultValue) !== -1 ){
+          def.default = true;
+        } else {
+          def.default = false;
+        }
+      } else if (this.defaultValue == 'uuid' || this.defaultValue == 'guid'){
+         def.defaultFn = this.defaultValue;
+      } else if ((this.type == 'date' || this.type == 'datetime') && this.defaultValue.toLowerCase() == "now"){
+         def.defaultFn = "now"
+      } else {
+         def.default = this.defaultValue;
+      }
     }
 
     this.modelDefinition.properties.create(def, function(err) {

--- a/property/index.js
+++ b/property/index.js
@@ -5,6 +5,7 @@ var chalk = require('chalk');
 var actions = require('../lib/actions');
 var helpers = require('../lib/helpers');
 var validateName = helpers.validateName;
+var checkPropertyName = helpers.checkPropertyName;
 var typeChoices = helpers.getTypeChoices();
 
 module.exports = yeoman.generators.Base.extend({
@@ -63,7 +64,7 @@ module.exports = yeoman.generators.Base.extend({
       {
         name: 'name',
         message: 'Enter the property name:',
-        validate: validateName,
+        validate: checkPropertyName,
         when: function() {
           return !this.name && this.name !== 0;
         }.bind(this)

--- a/property/index.js
+++ b/property/index.js
@@ -137,7 +137,7 @@ module.exports = yeoman.generators.Base.extend({
       def.required = true;
     }
     if (this.defaultValue) {
-      if (this.type == 'boolean'){
+      if (this.type === 'boolean'){
         if (['true', '1', 't'].indexOf(this.defaultValue) !== -1 ){
           def.default = true;
         } else {
@@ -145,8 +145,8 @@ module.exports = yeoman.generators.Base.extend({
         }
       } else if (this.defaultValue === 'uuid' || this.defaultValue === 'guid'){
          def.defaultFn = this.defaultValue;
-      } else if ((this.type === 'date' || this.type === 'datetime') 
-                  && this.defaultValue.toLowerCase() === 'now'){
+      } else if ((this.type === 'date' || this.type === 'datetime') &&
+                  this.defaultValue.toLowerCase() === 'now'){
          def.defaultFn = 'now';
       } else {
          def.default = this.defaultValue;

--- a/property/index.js
+++ b/property/index.js
@@ -143,10 +143,11 @@ module.exports = yeoman.generators.Base.extend({
         } else {
           def.default = false;
         }
-      } else if (this.defaultValue == 'uuid' || this.defaultValue == 'guid'){
+      } else if (this.defaultValue === 'uuid' || this.defaultValue === 'guid'){
          def.defaultFn = this.defaultValue;
-      } else if ((this.type == 'date' || this.type == 'datetime') && this.defaultValue.toLowerCase() == "now"){
-         def.defaultFn = "now"
+      } else if ((this.type === 'date' || this.type === 'datetime') 
+                  && this.defaultValue.toLowerCase() === 'now'){
+         def.defaultFn = 'now';
       } else {
          def.default = this.defaultValue;
       }

--- a/test/property.test.js
+++ b/test/property.test.js
@@ -40,7 +40,8 @@ describe('loopback:property generator', function() {
       customItemType: '', // temporary workaround for
                           // https://github.com/yeoman/generator/issues/600
       type: 'boolean',
-      required: 'true'
+      required: 'true',
+      defaultValue: 'true'
     });
 
     propertyGenerator.run(function() {
@@ -49,7 +50,8 @@ describe('loopback:property generator', function() {
       expect(props).to.have.property('isPreferred');
       expect(props.isPreferred).to.eql({
         type: 'boolean',
-        required: true
+        required: true,
+        default: true
       });
       done();
     });
@@ -72,6 +74,48 @@ describe('loopback:property generator', function() {
       var definition = common.readJsonSync('common/models/car.json');
       var prop = definition.properties.list;
       expect(prop.type).to.eql(['string']);
+      done();
+    });
+  });
+  
+  it('creates a defaultFn of "now" on date fields if specified', function(done) {
+    var propertyGenerator = givenPropertyGenerator();
+    helpers.mockPrompt(propertyGenerator, {
+      model: 'Car',
+      name: 'created',
+      type: 'date',
+      customType: '', // temporary workaround for
+                      // https://github.com/yeoman/generator/issues/600
+      customItemType: '', // temporary workaround for
+                          // https://github.com/yeoman/generator/issues/600
+      defaultValue: 'Now'
+    });
+
+    propertyGenerator.run(function() {
+      var definition = common.readJsonSync('common/models/car.json');
+      var prop = definition.properties.created;
+      expect(prop.defaultFn).to.eql('now');
+      done();
+    });
+  });
+
+  it('creates a defaultFn of "guid" on date fields if specified', function(done) {
+    var propertyGenerator = givenPropertyGenerator();
+    helpers.mockPrompt(propertyGenerator, {
+      model: 'Car',
+      name: 'uniqueId',
+      type: 'string',
+      customType: '', // temporary workaround for
+                      // https://github.com/yeoman/generator/issues/600
+      customItemType: '', // temporary workaround for
+                          // https://github.com/yeoman/generator/issues/600
+      defaultValue: 'uuid'
+    });
+
+    propertyGenerator.run(function() {
+      var definition = common.readJsonSync('common/models/car.json');
+      var prop = definition.properties.created;
+      expect(prop.defaultFn).to.eql('uuid');
       done();
     });
   });

--- a/test/property.test.js
+++ b/test/property.test.js
@@ -114,7 +114,7 @@ describe('loopback:property generator', function() {
 
     propertyGenerator.run(function() {
       var definition = common.readJsonSync('common/models/car.json');
-      var prop = definition.properties.created;
+      var prop = definition.properties.uniqueId;
       expect(prop.defaultFn).to.eql('uuid');
       done();
     });

--- a/test/property.test.js
+++ b/test/property.test.js
@@ -78,7 +78,7 @@ describe('loopback:property generator', function() {
     });
   });
   
-  it('creates a defaultFn of "now" on date fields if specified', function(done) {
+  it('creates a defaultFn: "now" on date fields if specified', function(done) {
     var propertyGenerator = givenPropertyGenerator();
     helpers.mockPrompt(propertyGenerator, {
       model: 'Car',
@@ -99,7 +99,7 @@ describe('loopback:property generator', function() {
     });
   });
 
-  it('creates a defaultFn of "guid" on date fields if specified', function(done) {
+  it('creates a defaultFn: "guid" on date fields if specified', function(done) {
     var propertyGenerator = givenPropertyGenerator();
     helpers.mockPrompt(propertyGenerator, {
       model: 'Car',


### PR DESCRIPTION
adds a prompt for a default value when a new property is created on a model.  Currently, it supports the boolean values of true and false, the special cases of "guid", "uuid", "now" on date/datetime, as well as strings.  

I'm not super in love with this nested if/else structure, but since everything comes back from the command line as a string which we have to parse (based on the property's type), I'm not immediately seeing a better way to do this.  Additionally "guid", "uuid", and "now" are special cases as they set the property "defaultFn" as opposed to just "default".  It's not elegant, but it does work.