### PR TITLE
Helpers to display correct usage message for apic

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -101,7 +101,15 @@ exports.checkRelationName = function (modelDefinition, name, callback) {
  * @returns {string}
  */
 exports.getCommandName = function() {
-  return process.env.SLC_COMMAND ? 'slc' : 'yo';
+  var command = 'yo';
+  if (process.env.SLC_COMMAND === 'apic'){
+    command = process.env.SLC_COMMAND;
+  } else if (process.env.SLC_COMMAND) {
+    // to preserve condition treating `process.env.SLC_COMMAND` as boolean
+    // cannot just use process.env.SLC_COMMAND as command due to regression
+    command = 'slc';
+  }
+  return command;
 };
 
 /**


### PR DESCRIPTION
This will require apic cli side to set `process.env.SLC_COMMAND` to apic 
Reason being we cannot set `command` directly from `process.env.SLC_COMMAND` is [this use case](https://github.com/strongloop/generator-loopback/blob/master/test/help.test.js#L27)

and `exports.getCommandName` is treating `process.env.SLC_COMMAND` as a boolean flag
