### PR TITLE
Only show editable model names in remote-method generator

### DIFF
--- a/remote-method/index.js
+++ b/remote-method/index.js
@@ -59,7 +59,7 @@ module.exports = yeoman.generators.Base.extend({
           name: 'model',
           message: 'Select the model:',
           type: 'list',
-          choices: this.modelNames
+          choices: this.editableModelNames
         }
       ];
       this.prompt(prompts, function(answers) {


### PR DESCRIPTION
I should update remote-method generator together in this commit: https://github.com/strongloop/generator-loopback/commit/326102606476eef244102aaaf9104237d03c7823

One line's change, could you review it @bajtos , thanks :)