### PR TITLE
Use http and verb

### DIFF
--- a/remote-method/index.js
+++ b/remote-method/index.js
@@ -157,8 +157,8 @@ module.exports = yeoman.generators.Base.extend({
 
       this.prompt(subprompts, function(answers) {
         this.http.push({
-          httpPath: httpPath,
-          httpVerb: answers.httpVerb || answers.customHttpVerb
+          path: httpPath,
+          verb: answers.httpVerb || answers.customHttpVerb
         });
         this.log('\nLet\'s add another endpoint.');
         this.askForEndpoints();


### PR DESCRIPTION
Related to : https://github.com/strongloop/loopback/issues/2070

In [remote-method](https://github.com/strongloop/generator-loopback/blob/master/remote-method/index.js#L160-L161) generator:
change `httpPath` to `path`
change `httpVerb` to `verb`
to make the setting work. `httpPath` and `httpVerb` are not recognized.

Otherwise remote method would use the default setting: `path`=methodname and `verb`=post