### PR TITLE
Add project template prompt, support apic

### DIFF
--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "js-yaml": "^3.4.2",
     "loopback-api-definition": "^1.0.0",
     "loopback-swagger": "^2.0.0",
-    "loopback-workspace": "^3.18.0",
+    "loopback-workspace": "^3.21.0",
     "mkdirp": "^0.5.1",
     "request": "^2.60.0",
     "yeoman-generator": "^0.21.1",


### PR DESCRIPTION
When creating a new LoopBack project, let the user choose a template they would like to use.

When running from apiconnect CLI, remove "api-server" from the templates list and offer "hello-world" as the default template.

Requires https://github.com/strongloop/loopback-workspace/pull/255

/to @ritch please review
/cc @kraman 