### PR TITLE
Add `yo loopback --skip-next-steps` options

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -28,6 +28,11 @@ module.exports = yeoman.generators.Base.extend({
       desc: 'Do not install npm dependencies.',
       type: Boolean
     });
+
+    this.option('skip-next-steps', {
+      desc: 'Do not print "next steps" info',
+      type: Boolean
+    });
   },
 
   greet: function() {
@@ -173,6 +178,8 @@ module.exports = yeoman.generators.Base.extend({
   installing: actions.installDeps,
 
   end: function() {
+    if (this.options.skipNextSteps) return;
+
     var cmd = helpers.getCommandName();
     if (!this._skipInstall) {
       this.log();


### PR DESCRIPTION
Add an option to suppress "next steps" banner, e.g. when running from a wrapper like `apic`.

/to @ritch please review
/cc @kraman 