### PR TITLE
Implement `yo loopback --no-explorer`

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -33,6 +33,11 @@ module.exports = yeoman.generators.Base.extend({
       desc: 'Do not print "next steps" info',
       type: Boolean
     });
+
+    this.option('explorer', {
+      desc: 'Add Loopback Explorer to the project (true by default)',
+      type: Boolean
+    });
   },
 
   greet: function() {
@@ -162,6 +167,9 @@ module.exports = yeoman.generators.Base.extend({
     Workspace.createFromTemplate(
       this.wsTemplate,
       this.appname,
+      {
+        'loopback-component-explorer': this.options.explorer !== false,
+      },
       done
     );
   },

--- a/package.json
+++ b/package.json
@@ -30,7 +30,7 @@
     "js-yaml": "^3.4.2",
     "loopback-api-definition": "^1.0.0",
     "loopback-swagger": "^2.0.0",
-    "loopback-workspace": "^3.21.0",
+    "loopback-workspace": "^3.22.0",
     "mkdirp": "^0.5.1",
     "request": "^2.60.0",
     "yeoman-generator": "^0.21.1",

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -7,6 +7,7 @@ var helpers = yg.test;
 var SANDBOX =  path.resolve(__dirname, 'sandbox');
 var common = require('./common');
 var assert = require('assert');
+var expect = require('chai').expect;
 var fs = require('fs');
 
 describe('loopback:app generator', function() {
@@ -93,6 +94,29 @@ describe('loopback:app generator', function() {
     gen.run(function() {
       var yoRcPath = path.resolve(SANDBOX, '.yo-rc.json');
       assert(fs.existsSync(yoRcPath), 'file exists');
+      done();
+    });
+  });
+
+  it('includes explorer by default', function(done) {
+    var gen = givenAppGenerator();
+    helpers.mockPrompt(gen, {dir: '.'});
+    gen.run(function() {
+      var compConfig = common.readJsonSync('server/component-config.json', {});
+      expect(Object.keys(compConfig))
+        .to.contain('loopback-component-explorer');
+      done();
+    });
+  });
+
+  it('excludes explorer with --no-explorer', function(done) {
+    var gen = givenAppGenerator();
+    gen.options.explorer = false;
+    helpers.mockPrompt(gen, {dir: '.'});
+    gen.run(function() {
+      var compConfig = common.readJsonSync('server/component-config.json', {});
+      expect(Object.keys(compConfig))
+        .to.not.contain('loopback-component-explorer');
       done();
     });
   });

--- a/test/common.js
+++ b/test/common.js
@@ -64,8 +64,11 @@ exports.createExampleGenerator = function() {
   return exports.createGenerator(name, path, deps, args, options);
 };
 
-exports.readJsonSync = function(relativePath) {
+exports.readJsonSync = function(relativePath, defaultValue) {
     var filepath = path.resolve(SANDBOX, relativePath);
+    if (defaultValue !== undefined && !fs.existsSync(filepath))
+      return defaultValue;
+
     var content = fs.readFileSync(filepath, 'utf-8');
     return JSON.parse(content);
 };


### PR DESCRIPTION
Add a new CLI option to scaffold a project without the API Explorer component.

Requires https://github.com/strongloop/loopback-workspace/pull/257
Connect to #153 

/to @ritch please review
