### PR TITLE
Remove prompt for datasources when none exist

### DIFF
--- a/model/index.js
+++ b/model/index.js
@@ -66,6 +66,7 @@ module.exports = yeoman.generators.Base.extend({
 
   askForParameters: function() {
     var done = this.async();
+    var hasDatasources = this.dataSources && this.dataSources.length > 1;
 
     this.displayName = chalk.yellow(this.name);
 
@@ -77,14 +78,6 @@ module.exports = yeoman.generators.Base.extend({
       }]);
 
     var prompts = [
-      {
-        name: 'dataSource',
-        message: 'Select the data-source to attach ' +
-          this.displayName + ' to:',
-        type: 'list',
-        default: 'db',
-        choices: this.dataSources
-      },
       {
         name: 'base',
         message: 'Select model\'s base class',
@@ -125,8 +118,24 @@ module.exports = yeoman.generators.Base.extend({
       }
     ];
 
+    if (hasDatasources) {
+      prompts.unshift({
+        name: 'dataSource',
+        message: 'Select the data-source to attach ' +
+          this.displayName + ' to:',
+        type: 'list',
+        default: 'db',
+        choices: this.dataSources
+      });
+    }
+
     this.prompt(prompts, function(props) {
-      this.dataSource = props.dataSource;
+      if (hasDatasources) {
+        this.dataSource = props.dataSource;
+      } else {
+        this.dataSource = null;
+      }
+
       this.public = props.public;
       this.plural = props.plural || undefined;
       this.base = props.customBase || props.base;

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -7,6 +7,8 @@ var fs = require('fs');
 var expect = require('chai').expect;
 var wsModels = require('loopback-workspace').models;
 var common = require('./common');
+var workspace = require('loopback-workspace');
+var Workspace = workspace.models.Workspace;
 
 describe('loopback:model generator', function() {
   beforeEach(common.resetWorkspace);
@@ -95,6 +97,31 @@ describe('loopback:model generator', function() {
       var product = readProductJsonSync();
       expect(product).to.have.property('base', 'CustomModel');
       done();
+    });
+  });
+
+  describe('in an empty project', function() {
+    beforeEach(common.resetWorkspace);
+    beforeEach(function createSandbox(done) {
+      helpers.testDirectory(SANDBOX, done);
+    });
+    beforeEach(function(done) {
+      process.env.WORKSPACE_DIR = SANDBOX;
+      Workspace.createFromTemplate('empty-server', 'empty', done);
+    });
+
+    it('should set dataSource to null', function(done) {
+      var modelGen = givenModelGenerator();
+      helpers.mockPrompt(modelGen, {
+        name: 'Product',
+        plural: 'pds'
+      });
+
+      modelGen.run(function() {
+        var modelConfig = readModelsJsonSync();
+        expect(modelConfig.Product.dataSource).to.eql(null);
+        done();
+      });
     });
   });
 


### PR DESCRIPTION
/to @raymondfeng 
/cc @bajtos 

This fixes https://github.ibm.com/apimesh/scrum-platform-foundation/issues/344

```
Right now, if you dont select anything and hit enter, it fails
$ apic loopback => Empty app
$ apic create --type model
? Enter the model name: m5
? Select the data-source to attach m5 to: (Use arrow keys)
(no data-source)

readline.js:924
throw err;
^
```