### PR TITLE
Fix data source ordier and default for models

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -158,10 +158,10 @@ actions.loadDataSources = function () {
 
 /**
  * Modify the list of datasources created by {@link loadDataSources}
- * and prepend an item for `null` datasource.
+ * and append an item for `null` datasource.
  */
 actions.addNullDataSourceItem = function() {
-  this.dataSources.unshift({
+  this.dataSources.push({
     name: '(no data-source)',
     value: null
   });

--- a/model/index.js
+++ b/model/index.js
@@ -72,10 +72,13 @@ module.exports = yeoman.generators.Base.extend({
     var defaultDS = null;
     if (hasDatasources) {
       var found = this.dataSources.some(function(ds) {
-        return ds.name === 'db';
+        return ds.value === 'db';
       });
       if (found) {
         defaultDS = 'db';
+      } else {
+        // default to 1st one
+        defaultDS = this.dataSources[0].value;
       }
     }
 


### PR DESCRIPTION
This PR has two fixes:

1. Make sure `null` data source is the last option of the list
2. Fix how default `db` is tested
3. Default to `db` if it exists, otherwise the first datasource