### PR TITLE
Exit gracefully when generator errors

### DIFF
--- a/datasource/index.js
+++ b/datasource/index.js
@@ -28,6 +28,10 @@ module.exports = yeoman.generators.Base.extend({
       required: false,
       type: String
     });
+
+    this.on('error', function(err) {
+      this.env._lb_abort = err;
+    });
   },
 
   help: function() {
@@ -35,6 +39,7 @@ module.exports = yeoman.generators.Base.extend({
   },
 
   loadConnectors: function() {
+    if (this.env._lb_abort) return;
     var done = this.async();
     wsModels.Workspace.listAvailableConnectors(function(err, list) {
       if (err) {
@@ -66,6 +71,7 @@ module.exports = yeoman.generators.Base.extend({
   },
 
   askForName: function() {
+    if (this.env._lb_abort) return;
     var done = this.async();
 
     var prompts = [
@@ -91,6 +97,7 @@ module.exports = yeoman.generators.Base.extend({
   },
 
   askForParameters: function() {
+    if (this.env._lb_abort) return;
     var done = this.async();
 
     var displayName = chalk.yellow(this.name);
@@ -123,6 +130,7 @@ module.exports = yeoman.generators.Base.extend({
   },
 
   askForConfig: function() {
+    if (this.env._lb_abort) return;
     var self = this;
     var settings = this.connectorSettings[this.connector];
     this.settings = {};
@@ -198,6 +206,7 @@ module.exports = yeoman.generators.Base.extend({
   },
 
   installConnector: function() {
+    if (this.env._lb_abort) return;
     var connector = this.availableConnectors[this.connector];
     var pkg = connector.package;
     if (!pkg) return;
@@ -234,6 +243,7 @@ module.exports = yeoman.generators.Base.extend({
   },
 
   dataSource: function() {
+    if (this.env._lb_abort) return;
     var done = this.async();
     var config = extend(this.settings, {
       name: this.name,

--- a/model/index.js
+++ b/model/index.js
@@ -31,6 +31,10 @@ module.exports = yeoman.generators.Base.extend({
     //   "generator#invoke() is deprecated. Use generator#composeWith()"
     // See https://github.com/strongloop/generator-loopback/issues/116
     this.invoke = require('yeoman-generator/lib/actions/invoke');
+
+    this.on('error', function(err) {
+      this.env._lb_abort = err;
+    });
   },
 
   help: function() {
@@ -46,6 +50,7 @@ module.exports = yeoman.generators.Base.extend({
   addNullDataSourceItem: actions.addNullDataSourceItem,
 
   askForName: function() {
+    if (this.env._lb_abort) return;
     var done = this.async();
 
     var prompts = [
@@ -65,6 +70,7 @@ module.exports = yeoman.generators.Base.extend({
   },
 
   getBaseModels: function() {
+    if (this.env._lb_abort) return;
     var done = this.async();
     helpers.getBaseModelForDataSourceName(
       this.dataSource, this.dataSources, function(err, models) {
@@ -75,6 +81,7 @@ module.exports = yeoman.generators.Base.extend({
   },
 
   askForParameters: function() {
+    if (this.env._lb_abort) return;
     var done = this.async();
 
     this.displayName = chalk.yellow(this.name);
@@ -152,6 +159,7 @@ module.exports = yeoman.generators.Base.extend({
   },
 
   modelDefinition: function() {
+    if (this.env._lb_abort) return;
     var done = this.async();
     var config = {
       name: this.name,
@@ -167,6 +175,7 @@ module.exports = yeoman.generators.Base.extend({
   },
 
   modelConfiguration: function() {
+    if (this.env._lb_abort) return;
     var done = this.async();
     var config = {
       name: this.name,
@@ -182,10 +191,12 @@ module.exports = yeoman.generators.Base.extend({
   },
 
   delim: function() {
+    if (this.env._lb_abort) return;
     this.log('Let\'s add some ' + this.displayName + ' properties now.\n');
   },
 
   property: function() {
+    if (this.env._lb_abort) return;
     var done = this.async();
     this.log('Enter an empty property name when done.');
     var prompts = [


### PR DESCRIPTION
Currently invalid user input results in an ugly stack trace. This PR changes behavior to skip follow-on steps if one of the previous steps has erred.

```
$ apic  create --type datasource 
? Enter the data-source name: 
? Select the connector for : In-memory db (supported by StrongLoop)
Connector-specific configuration:
? window.localStorage key to use for persistence (browser only): 
? Full path to file for persistence (server only): 
Validation error: invalid DataSourceDefinition
 - name: can't be blank,can't be blank

events.js:141
      throw er; // Unhandled 'error' event
      ^
ValidationError: The `DataSourceDefinition` instance is not valid. Details: `name` can't be blank (value: ""); `name` can't be blank (value: "").
    at /usr/local/lib/node_modules/apiconnect/node_modules/apiconnect-cli-loopback/node_modules/generator-loopback/node_modules/loopback-workspace/node_modules/loopback-datasource-juggler/lib/dao.js:317:12
    at ModelConstructor.<anonymous> (/usr/local/lib/node_modules/apiconnect/node_modules/apiconnect-cli-loopback/node_modules/generator-loopback/node_modules/loopback-workspace/node_modules/loopback-datasource-juggler/lib/validations.js:487:13)
    at ModelConstructor.next (/usr/local/lib/node_modules/apiconnect/node_modules/apiconnect-cli-loopback/node_modules/generator-loopback/node_modules/loopback-workspace/node_modules/loopback-datasource-juggler/lib/hooks.js:75:12)
    at done (/usr/local/lib/node_modules/apiconnect/node_modules/apiconnect-cli-loopback/node_modules/generator-loopback/node_modules/loopback-workspace/node_modules/loopback-datasource-juggler/lib/validations.js:484:25)
    at /usr/local/lib/node_modules/apiconnect/node_modules/apiconnect-cli-loopback/node_modules/generator-loopback/node_modules/loopback-workspace/node_modules/loopback-datasource-juggler/lib/validations.js:558:7
    at doNTCallback0 (node.js:417:9)
    at process._tickDomainCallback (node.js:387:13)
    at process.<anonymous> (/usr/local/lib/node_modules/apiconnect/node_modules/apiconnect-cli-loopback/node_modules/generator-loopback/node_modules/loopback-workspace/node_modules/loopback/node_modules/continuation-local-storage/node_modules/async-listener/index.js:19:15)
```