### PR TITLE
typo 'funtion'

### DIFF
--- a/remote-method/index.js
+++ b/remote-method/index.js
@@ -388,7 +388,7 @@ function buildMethodSource(def) {
     def.methodName
   );
   var functionDef = [util.format(
-    ref + ' = funtion(%s) {',
+    ref + ' = function(%s) {',
     chalk.green(buildInputArgs(def.accepts).join(', '))
     )
   ];


### PR DESCRIPTION
Doesn't break anything.  It shows up in the code sample output from `slc loopback:remote-method`.

ex:

```javascript
// We have added strong-remoting metadata for your new method to common/models/gift.json
// Now it's up to you to provide implementation in common/models/gift.js
// Here is a sample code to get you started:

/**
 * List all available gifts
 * @param {Function(Error, array)} callback
 */

Gift.listFree = funtion(callback) {
  var gifts;
  // TODO
  callback(null, gifts);
};
```