### PR TITLE
Fix accept and return to end with empty input

### DIFF
--- a/boot-script/index.js
+++ b/boot-script/index.js
@@ -3,6 +3,8 @@ var helpers = require('../lib/helpers');
 var path = require('path');
 var yeoman = require('yeoman-generator');
 
+var validateRequiredName = helpers.validateRequiredName;
+
 module.exports = yeoman.generators.Base.extend({
   constructor: function() {
     yeoman.generators.Base.apply(this, arguments);
@@ -28,7 +30,7 @@ module.exports = yeoman.generators.Base.extend({
       name: 'name',
       message: 'Enter the script name (without `.js`):',
       default: this.name,
-      validate: helpers.validateName
+      validate: validateRequiredName
     };
 
     this.prompt(question, function(answer) {

--- a/datasource/index.js
+++ b/datasource/index.js
@@ -7,7 +7,7 @@ var wsModels = require('loopback-workspace').models;
 
 var actions = require('../lib/actions');
 var helpers = require('../lib/helpers');
-var validateName = helpers.validateName;
+var validateRequiredName = helpers.validateRequiredName;
 var objectValidator = helpers.objectValidator;
 var path = require('path');
 var fs = require('fs');
@@ -73,13 +73,7 @@ module.exports = yeoman.generators.Base.extend({
         name: 'name',
         message: 'Enter the data-source name:',
         default: this.name,
-        validate: function(name) {
-          if (!name) {
-            return 'Name is required';
-          } else {
-            return validateName(name);
-          }
-        }
+        validate: validateRequiredName
       }
     ];
 
@@ -109,7 +103,7 @@ module.exports = yeoman.generators.Base.extend({
         name: 'customConnector',
         message:
           'Enter the connector name without the loopback-connector- prefix:',
-        validate: validateName,
+        validate: validateRequiredName,
         when: function(answers) {
           return answers.connector === 'other';
         }

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -51,7 +51,7 @@ exports.validateAppName = function (name) {
  * @returns {String|Boolean}
  */
 exports.checkPropertyName = function(name) {
-  var result = exports.validateName(name);
+  var result = exports.validateRequiredName(name);
   if (result !== true) return result;
   if (RESERVED_PROPERTY_NAMES.indexOf(name) !== -1) {
     return name + ' is a reserved keyword. Please use another name';
@@ -60,14 +60,25 @@ exports.checkPropertyName = function(name) {
 };
 
 /**
- * Validate name for properties, data sources, or connectors
+ * Validate required name for properties, data sources, or connectors
+ * Empty name could not pass
  * @param {String} name The user input
  * @returns {String|Boolean}
  */
-exports.validateName = function (name) {
+exports.validateRequiredName = function (name) {
   if (!name) {
     return 'Name is required';
   }
+  return exports.validateOptionalName(name);
+};
+
+/**
+ * Validate optional name for properties, data sources, or connectors
+ * Empty name could pass
+ * @param {String} name The user input
+ * @returns {String|Boolean}
+ */
+exports.validateOptionalName = function (name) {
   if (name.match(/[\/@\s\+%:\.]/)) {
     return 'Name cannot contain special characters (/@+%:. ): ' + name;
   }

--- a/middleware/index.js
+++ b/middleware/index.js
@@ -6,7 +6,7 @@ var wsModels = require('loopback-workspace').models;
 
 var actions = require('../lib/actions');
 var helpers = require('../lib/helpers');
-var validateName = helpers.validateName;
+var validateRequiredName = helpers.validateRequiredName;
 
 function toNumberedList(items) {
   var lastIndex = items.length - 1;
@@ -70,9 +70,7 @@ module.exports = yeoman.generators.Base.extend({
         name: 'name',
         message: 'Enter the middleware name:',
         default: this.name,
-        validate: function(name) {
-          return name && validateName(name);
-        }
+        validate: validateRequiredName
       }
     ];
 
@@ -99,7 +97,7 @@ module.exports = yeoman.generators.Base.extend({
       {
         name: 'customPhase',
         message: 'Enter the phase name:',
-        validate: validateName,
+        validate: validateRequiredName,
         when: function(answers) {
           return answers.phase === OTHER_PHASE;
         }

--- a/model/index.js
+++ b/model/index.js
@@ -5,7 +5,8 @@ var wsModels = require('loopback-workspace').models;
 
 var actions = require('../lib/actions');
 var helpers = require('../lib/helpers');
-var validateName = helpers.validateName;
+var validateRequiredName = helpers.validateRequiredName;
+var validateOptionalName = helpers.validateOptionalName;
 
 module.exports = yeoman.generators.Base.extend({
   // NOTE(bajtos)
@@ -53,7 +54,7 @@ module.exports = yeoman.generators.Base.extend({
         name: 'name',
         message: 'Enter the model name:',
         default: this.name,
-        validate: validateName
+        validate: validateRequiredName
       }
     ];
 
@@ -128,7 +129,7 @@ module.exports = yeoman.generators.Base.extend({
         name: 'customBase',
         message: 'Enter the base model name:',
         required: true,
-        validate: validateName,
+        validate: validateRequiredName,
         when: function(answers) {
           return answers.base === null;
         }
@@ -205,13 +206,7 @@ module.exports = yeoman.generators.Base.extend({
       {
         name: 'propertyName',
         message: 'Property name:',
-        validate: function (input) {
-          if (input) {
-            return validateName(input);
-          } else {
-            return true;
-          }
-        }
+        validate: validateOptionalName
       }
     ];
     this.prompt(prompts, function(answers) {

--- a/property/index.js
+++ b/property/index.js
@@ -4,7 +4,7 @@ var chalk = require('chalk');
 
 var actions = require('../lib/actions');
 var helpers = require('../lib/helpers');
-var validateName = helpers.validateName;
+var validateRequiredName = helpers.validateRequiredName;
 var checkPropertyName = helpers.checkPropertyName;
 var typeChoices = helpers.getTypeChoices();
 
@@ -79,7 +79,7 @@ module.exports = yeoman.generators.Base.extend({
         name: 'customType',
         message: 'Enter the type:',
         required: true,
-        validate: validateName,
+        validate: validateRequiredName,
         when: function(answers) {
           return answers.type === null;
         }
@@ -96,7 +96,7 @@ module.exports = yeoman.generators.Base.extend({
       {
         name: 'customItemType',
         message: 'Enter the item type:',
-        validate: validateName,
+        validate: validateRequiredName,
         when: function(answers) {
           return answers.type === 'array' && answers.itemType === null;
         }

--- a/relation/index.js
+++ b/relation/index.js
@@ -8,7 +8,8 @@ var ModelRelation = workspace.models.ModelRelation;
 
 var actions = require('../lib/actions');
 var helpers = require('../lib/helpers');
-var validateName = helpers.validateName;
+var validateOptionalName = helpers.validateOptionalName;
+var validateRequiredName = helpers.validateRequiredName;
 var checkRelationName = helpers.checkRelationName;
 var checkPropertyName = helpers.checkPropertyName;
 
@@ -92,7 +93,7 @@ module.exports = yeoman.generators.Base.extend({
         name: 'customToModel',
         message: 'Enter the model name:',
         required: true,
-        validate: validateName,
+        validate: validateRequiredName,
         when: function(answers) {
           return answers.toModel === null;
         }
@@ -120,9 +121,7 @@ module.exports = yeoman.generators.Base.extend({
       {
         name: 'foreignKey',
         message: 'Optionally enter a custom foreign key:',
-        validate: function(value) {
-          return value === undefined || value === '' || validateName(value);
-        }
+        validate: validateOptionalName
       },
       {
         name: 'through',
@@ -146,7 +145,7 @@ module.exports = yeoman.generators.Base.extend({
         name: 'customThroughModel',
         message: 'Enter the model name:',
         required: true,
-        validate: validateName,
+        validate: validateRequiredName,
         when: function(answers) {
           return answers.through && answers.throughModel === null;
         }

--- a/remote-method/index.js
+++ b/remote-method/index.js
@@ -6,7 +6,8 @@ var path = require('path');
 
 var actions = require('../lib/actions');
 var helpers = require('../lib/helpers');
-var validateName = helpers.validateName;
+var validateRequiredName = helpers.validateRequiredName;
+var validateOptionalName = helpers.validateOptionalName;
 var checkPropertyName = helpers.checkPropertyName;
 var typeChoices = helpers.getTypeChoices();
 var ModelDefinition = require('loopback-workspace').models.ModelDefinition;
@@ -146,7 +147,7 @@ module.exports = yeoman.generators.Base.extend({
           name: 'customHttpVerb',
           message:
           'Enter the custom http verb',
-          validate: validateName,
+          validate: validateRequiredName,
           when: function(answers) {
             return answers.httpVerb === null;
           }
@@ -180,7 +181,7 @@ module.exports = yeoman.generators.Base.extend({
         name: 'acceptsArg',
         message: 'Enter name for accept argument:',
         required: true,
-        validate: validateName
+        validate: validateOptionalName
       }
     ];
     this.prompt(prompts, function(answers) {
@@ -270,7 +271,7 @@ module.exports = yeoman.generators.Base.extend({
         name: 'returnsArg',
         message: 'Enter name for return argument:',
         required: true,
-        validate: validateName
+        validate: validateOptionalName
       }
     ];
     this.prompt(prompts, function(answers) {

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -2,7 +2,8 @@
 'use strict';
 var helpers = require('../lib/helpers');
 var validateAppName = helpers.validateAppName;
-var validateName = helpers.validateName;
+var validateOptionalName = helpers.validateOptionalName;
+var validateRequiredName = helpers.validateRequiredName;
 var checkRelationName = helpers.checkRelationName;
 require('chai').should();
 var expect = require('chai').expect;
@@ -40,26 +41,32 @@ describe('helpers', function() {
 
   });
 
-  describe('validateName()', function() {
+  describe('validateRequiredName()', function() {
     it('should accept good names', function() {
-      testValidationAcceptsValue(validateName, 'prop');
-      testValidationAcceptsValue(validateName, 'prop1');
-      testValidationAcceptsValue(validateName, 'my_prop');
-      testValidationAcceptsValue(validateName, 'my-prop');
+      testValidationAcceptsValue(validateRequiredName, 'prop');
+      testValidationAcceptsValue(validateRequiredName, 'prop1');
+      testValidationAcceptsValue(validateRequiredName, 'my_prop');
+      testValidationAcceptsValue(validateRequiredName, 'my-prop');
     });
 
     it('should report errors for a name containing special chars', function() {
-      testValidationRejectsValue(validateName, 'my prop');
-      testValidationRejectsValue(validateName, 'my/prop');
-      testValidationRejectsValue(validateName, 'my@prop');
-      testValidationRejectsValue(validateName, 'my+prop');
-      testValidationRejectsValue(validateName, 'my%prop');
-      testValidationRejectsValue(validateName, 'my:prop');
-      testValidationRejectsValue(validateName, 'm.prop');
+      testValidationRejectsValue(validateRequiredName, 'my prop');
+      testValidationRejectsValue(validateRequiredName, 'my/prop');
+      testValidationRejectsValue(validateRequiredName, 'my@prop');
+      testValidationRejectsValue(validateRequiredName, 'my+prop');
+      testValidationRejectsValue(validateRequiredName, 'my%prop');
+      testValidationRejectsValue(validateRequiredName, 'my:prop');
+      testValidationRejectsValue(validateRequiredName, 'm.prop');
     });
 
     it('should report errors for an empty name', function() {
-      testValidationRejectsValue(validateName, '');
+      testValidationRejectsValue(validateRequiredName, '');
+    });
+  });
+
+  describe('validateOptionalName()', function() {
+    it('should accept empty name', function() {
+      testValidationAcceptsValue(validateOptionalName, '');
     });
   });
 


### PR DESCRIPTION
Add empty check to `validName` breaks remote-method generator, since in accept and return prompt, it checks validation before checking empty. 
I change the logic in remote-method generator so empty input could pass.