### PR TITLE
Fixes datasource generation with community connector

### DIFF
--- a/datasource/index.js
+++ b/datasource/index.js
@@ -198,6 +198,7 @@ module.exports = yeoman.generators.Base.extend({
 
   installConnector: function() {
     var connector = this.availableConnectors[this.connector];
+    if (!connector) return;
     var pkg = connector.package;
     if (!pkg) return;
 


### PR DESCRIPTION
Community connectors are not listed in availableConnectors, causing the following when a user chooses 'other' and enters a community connector:

ERROR Cannot read property 'package' of undefined

Fix makes function return when this is the case, allowing generator to proceed creating skeleton record in datasources.json