### PR TITLE
Fix unit test with yeoman-test

### DIFF
--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
     "glob": "^6.0.1",
     "jshint": "^2.8.0",
     "mocha": "^2.2.5",
-    "strong-cached-install": "^2.0.0"
+    "strong-cached-install": "^2.0.0",
+    "yeoman-test": "^1.4.0"
   }
 }

--- a/test/acl.test.js
+++ b/test/acl.test.js
@@ -11,6 +11,7 @@ var wsModels = require('loopback-workspace').models;
 var SANDBOX =  path.resolve(__dirname, 'sandbox');
 var expect = require('chai').expect;
 var common = require('./common');
+var testhelpers = require('yeoman-test');
 
 describe('loopback:acl generator', function() {
   beforeEach(function createSandbox(done) {
@@ -46,7 +47,7 @@ describe('loopback:acl generator', function() {
 
   it('adds an entry to models.json', function(done) {
     var aclGen = givenAclGenerator();
-    helpers.mockPrompt(aclGen, {
+    testhelpers.mockPrompt(aclGen, {
       model: 'Car',
       scope: 'all',
       accessType: '*',
@@ -70,7 +71,7 @@ describe('loopback:acl generator', function() {
 
   it('skips accessType is the scope is method', function(done) {
     var aclGen = givenAclGenerator();
-    helpers.mockPrompt(aclGen, {
+    testhelpers.mockPrompt(aclGen, {
       model: 'Car',
       scope: 'method',
       property: 'find',
@@ -95,7 +96,7 @@ describe('loopback:acl generator', function() {
 
   it('adds an entry to models.json for custom role', function(done) {
     var aclGen = givenAclGenerator();
-    helpers.mockPrompt(aclGen, {
+    testhelpers.mockPrompt(aclGen, {
       model: 'Car',
       scope: 'all',
       accessType: '*',
@@ -120,7 +121,7 @@ describe('loopback:acl generator', function() {
 
   it('adds an entry to all models.json', function(done) {
     var aclGen = givenAclGenerator();
-    helpers.mockPrompt(aclGen, {
+    testhelpers.mockPrompt(aclGen, {
       scope: 'all',
       accessType: '*',
       role: '$owner',

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -14,6 +14,7 @@ var common = require('./common');
 var assert = require('assert');
 var expect = require('chai').expect;
 var fs = require('fs');
+var testhelpers = require('yeoman-test');
 
 describe('loopback:app generator', function() {
   beforeEach(common.resetWorkspace);
@@ -41,7 +42,7 @@ describe('loopback:app generator', function() {
 
     var gen = givenAppGenerator();
 
-    helpers.mockPrompt(gen, {
+    testhelpers.mockPrompt(gen, {
       name: 'test-app',
       template: 'api-server'
     });
@@ -56,7 +57,7 @@ describe('loopback:app generator', function() {
   it('creates the project in a subdirectory if asked to', function(done) {
     var gen = givenAppGenerator();
 
-    helpers.mockPrompt(gen, {
+    testhelpers.mockPrompt(gen, {
       appname: 'test-app',
       template: 'api-server',
       dir: 'test-dir',
@@ -95,7 +96,7 @@ describe('loopback:app generator', function() {
 
   it('should create .yo-rc.json', function(done) {
     var gen = givenAppGenerator();
-    helpers.mockPrompt(gen, {dir: '.'});
+    testhelpers.mockPrompt(gen, {dir: '.'});
     gen.run(function() {
       var yoRcPath = path.resolve(SANDBOX, '.yo-rc.json');
       assert(fs.existsSync(yoRcPath), 'file exists');
@@ -105,7 +106,7 @@ describe('loopback:app generator', function() {
 
   it('includes explorer by default', function(done) {
     var gen = givenAppGenerator();
-    helpers.mockPrompt(gen, {dir: '.'});
+    testhelpers.mockPrompt(gen, {dir: '.'});
     gen.run(function() {
       var compConfig = common.readJsonSync('server/component-config.json', {});
       expect(Object.keys(compConfig))
@@ -117,7 +118,7 @@ describe('loopback:app generator', function() {
   it('excludes explorer with --no-explorer', function(done) {
     var gen = givenAppGenerator();
     gen.options.explorer = false;
-    helpers.mockPrompt(gen, {dir: '.'});
+    testhelpers.mockPrompt(gen, {dir: '.'});
     gen.run(function() {
       var compConfig = common.readJsonSync('server/component-config.json', {});
       expect(Object.keys(compConfig))
@@ -126,10 +127,10 @@ describe('loopback:app generator', function() {
     });
   });
 
-  function givenAppGenerator(modelArgs) {
+  function givenAppGenerator() {
     var name = 'loopback:app';
     var path = '../../app';
-    var gen = common.createGenerator(name, path, [], modelArgs, {});
+    var gen = common.createGenerator(name, path);
     gen.options['skip-install'] = true;
     return gen;
   }
@@ -138,7 +139,7 @@ describe('loopback:app generator', function() {
     var gen = givenAppGenerator();
     var dir = path.join(SANDBOX, cwdName);
     helpers.testDirectory(dir, function() {
-      helpers.mockPrompt(gen, {
+      testhelpers.mockPrompt(gen, {
         wsTemplate: 'api-server',
         dir: '.'
       });

--- a/test/boot-script.test.js
+++ b/test/boot-script.test.js
@@ -11,6 +11,7 @@ var SANDBOX =  path.resolve(__dirname, 'sandbox');
 var fs = require('fs');
 var expect = require('chai').expect;
 var common = require('./common');
+var testhelpers = require('yeoman-test');
 
 describe('loopback:boot-script generator', function() {
   beforeEach(common.resetWorkspace);
@@ -25,7 +26,7 @@ describe('loopback:boot-script generator', function() {
 
   it('generates an async boot script properly', function(done) {
     var bootGen = givenBootScriptGenerator();
-    helpers.mockPrompt(bootGen, {
+    testhelpers.mockPrompt(bootGen, {
       name: 'async-boot-script',
       type: 'async'
     });
@@ -45,7 +46,7 @@ describe('loopback:boot-script generator', function() {
 
   it('generates a sync boot script properly', function(done) {
     var bootGen = givenBootScriptGenerator();
-    helpers.mockPrompt(bootGen, {
+    testhelpers.mockPrompt(bootGen, {
       name: 'sync-boot-script',
       type: 'sync'
     });
@@ -63,10 +64,10 @@ describe('loopback:boot-script generator', function() {
     });
   });
 
-  function givenBootScriptGenerator(bsArgs) {
+  function givenBootScriptGenerator() {
     var path = '../../boot-script';
     var name = 'loopback:boot-script';
-    var gen = common.createGenerator(name, path, [], bsArgs, {});
+    var gen = common.createGenerator(name, path);
     return gen;
   }
 });

--- a/test/common.js
+++ b/test/common.js
@@ -8,24 +8,15 @@ var async = require('async');
 var fs = require('fs');
 var path = require('path');
 var SANDBOX =  path.resolve(__dirname, 'sandbox');
-var generators = require('yeoman-generator');
+var helpers = require('yeoman-test');
 var workspace = require('loopback-workspace');
 var Workspace = workspace.models.Workspace;
 
 exports.createGenerator = createGenerator;
 
-function createGenerator(name, path, deps, args, opts) {
-  var env = generators();
-
-  deps = deps || [];
-  deps.forEach(function(d) {
-    d = Array.isArray(d) ? d : [d];
-    env.register.apply(env, d);
-  });
-
-  env.register(path, name);
-
-  return env.create(name, { arguments: args || [], options: opts || {} });
+function createGenerator(name, path, args, opts) {
+  path = Array.isArray(path) ? path : [path];
+  return helpers.createGenerator(name, path, args, opts);
 }
 
 exports.createDummyProject = function(dir, name, done) {
@@ -55,18 +46,6 @@ exports.findAllGeneratorsExcept = function(except) {
     .map(function(name) {
       return ['../../' + name, 'loopback:' + name];
     });
-};
-
-exports.createExampleGenerator = function() {
-  var name = 'example';
-  var path = '../../example';
-  var deps = exports.findAllGeneratorsExcept('example');
-  var args = [];
-  var options = {
-    'skip-install': true
-  };
-
-  return exports.createGenerator(name, path, deps, args, options);
 };
 
 exports.readJsonSync = function(relativePath, defaultValue) {

--- a/test/datasource.test.js
+++ b/test/datasource.test.js
@@ -11,6 +11,7 @@ var SANDBOX =  path.resolve(__dirname, 'sandbox');
 var fs = require('fs');
 var expect = require('chai').expect;
 var common = require('./common');
+var testhelpers = require('yeoman-test');
 
 describe('loopback:datasource generator', function() {
   beforeEach(common.resetWorkspace);
@@ -25,7 +26,7 @@ describe('loopback:datasource generator', function() {
 
   it('adds an entry to server/datasources.json', function(done) {
     var modelGen = givenDataSourceGenerator();
-    helpers.mockPrompt(modelGen, {
+    testhelpers.mockPrompt(modelGen, {
       name: 'crm',
       customConnector: '', // temporary workaround for
                            // https://github.com/yeoman/generator/issues/600
@@ -44,7 +45,7 @@ describe('loopback:datasource generator', function() {
 
   it('allow connector without settings', function(done) {
     var modelGen = givenDataSourceGenerator();
-    helpers.mockPrompt(modelGen, {
+    testhelpers.mockPrompt(modelGen, {
       name: 'kafka1',
       customConnector: '', // temporary workaround for
                            // https://github.com/yeoman/generator/issues/600
@@ -63,7 +64,7 @@ describe('loopback:datasource generator', function() {
 
   it('should install connector module on demand', function(done) {
     var modelGen = givenDataSourceGenerator();
-    helpers.mockPrompt(modelGen, {
+    testhelpers.mockPrompt(modelGen, {
       name: 'rest0',
       customConnector: '', // temporary workaround for
                            // https://github.com/yeoman/generator/issues/600
@@ -88,7 +89,7 @@ describe('loopback:datasource generator', function() {
       }
     };
     var modelGen = givenDataSourceGenerator();
-    helpers.mockPrompt(modelGen, {
+    testhelpers.mockPrompt(modelGen, {
       name: 'rest1',
       customConnector: '', // temporary workaround for
                            // https://github.com/yeoman/generator/issues/600
@@ -110,10 +111,10 @@ describe('loopback:datasource generator', function() {
     });
   });
 
-  function givenDataSourceGenerator(dsArgs) {
+  function givenDataSourceGenerator() {
     var path = '../../datasource';
     var name = 'loopback:datasource';
-    var gen = common.createGenerator(name, path, [], dsArgs, {});
+    var gen = common.createGenerator(name, path);
     return gen;
   }
 

--- a/test/export-api-def.test.js
+++ b/test/export-api-def.test.js
@@ -102,10 +102,10 @@ describe('loopback:export-api-def generator', function() {
     });
   });
 
-  function givenGenerator(args) {
+  function givenGenerator() {
     var path = '../../export-api-def';
     var name = 'loopback:export-api-def';
-    var gen = common.createGenerator(name, path, [], args);
+    var gen = common.createGenerator(name, path);
     gen.options['skip-install'] = false;
     return gen;
   }

--- a/test/help.test.js
+++ b/test/help.test.js
@@ -48,7 +48,7 @@ describe('loopback generator help', function () {
   function givenGenerator(name, modelArgs) {
     var fullName = 'loopback:' + name;
     var path = '../../' + name;
-    var gen = common.createGenerator(fullName, path, [], modelArgs, {});
+    var gen = common.createGenerator(fullName, path, modelArgs);
     return gen;
   }
 });

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -11,6 +11,7 @@ var SANDBOX = path.resolve(__dirname, 'sandbox');
 var fs = require('fs');
 var expect = require('chai').expect;
 var common = require('./common');
+var testhelpers = require('yeoman-test');
 
 describe('loopback:middleware generator', function() {
   beforeEach(common.resetWorkspace);
@@ -24,7 +25,7 @@ describe('loopback:middleware generator', function() {
 
   it('adds a new phase to server/middleware.json', function(done) {
     var modelGen = givenMiddlewareGenerator();
-    helpers.mockPrompt(modelGen, {
+    testhelpers.mockPrompt(modelGen, {
       name: 'my-middleware-1',
       phase: 'my-phase',
       paths: ['/x', '/y'],
@@ -42,7 +43,7 @@ describe('loopback:middleware generator', function() {
 
   it('adds a new phase next to a selected one', function(done) {
     var modelGen = givenMiddlewareGenerator();
-    helpers.mockPrompt(modelGen, {
+    testhelpers.mockPrompt(modelGen, {
       name: 'my-middleware-2',
       phase: '(custom phase)',
       customPhase: 'my-phase-2',
@@ -63,7 +64,7 @@ describe('loopback:middleware generator', function() {
   it('adds a new entry to an existing phase in server/middleware.json',
     function(done) {
       var modelGen = givenMiddlewareGenerator();
-      helpers.mockPrompt(modelGen, {
+      testhelpers.mockPrompt(modelGen, {
         name: 'my-middleware-3',
         phase: 'routes',
         paths: ['/x', '/y'],
@@ -82,7 +83,7 @@ describe('loopback:middleware generator', function() {
 
   it('supports sub-phase', function(done) {
       var modelGen = givenMiddlewareGenerator();
-      helpers.mockPrompt(modelGen, {
+      testhelpers.mockPrompt(modelGen, {
         name: 'my-middleware-4',
         phase: 'routes',
         subPhase: 'after',
@@ -101,10 +102,10 @@ describe('loopback:middleware generator', function() {
       });
     });
 
-  function givenMiddlewareGenerator(dsArgs) {
+  function givenMiddlewareGenerator() {
     var path = '../../middleware';
     var name = 'loopback:middleware';
-    var gen = common.createGenerator(name, path, [], dsArgs, {});
+    var gen = common.createGenerator(name, path);
     return gen;
   }
 

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -14,6 +14,7 @@ var wsModels = require('loopback-workspace').models;
 var common = require('./common');
 var workspace = require('loopback-workspace');
 var Workspace = workspace.models.Workspace;
+var testhelpers = require('yeoman-test');
 
 describe('loopback:model generator', function() {
   beforeEach(common.resetWorkspace);
@@ -36,7 +37,7 @@ describe('loopback:model generator', function() {
 
   it('creates common/models/{name}.json', function(done) {
     var modelGen = givenModelGenerator();
-    helpers.mockPrompt(modelGen, {
+    testhelpers.mockPrompt(modelGen, {
       name: 'Product',
       plural: 'pds',
       dataSource: 'db'
@@ -53,7 +54,7 @@ describe('loopback:model generator', function() {
 
   it('adds an entry to server/models.json', function(done) {
     var modelGen = givenModelGenerator();
-    helpers.mockPrompt(modelGen, {
+    testhelpers.mockPrompt(modelGen, {
       name: 'Product',
       dataSource: 'db',
       public: false,
@@ -76,7 +77,7 @@ describe('loopback:model generator', function() {
 
   it('sets `base` option from the list', function(done) {
     var modelGen = givenModelGenerator();
-    helpers.mockPrompt(modelGen, {
+    testhelpers.mockPrompt(modelGen, {
       name: 'Product',
       dataSource: 'db',
       base: 'PersistedModel'
@@ -91,7 +92,7 @@ describe('loopback:model generator', function() {
 
   it('sets `dataSource` option to db by default', function(done) {
     var modelGen = givenModelGenerator();
-    helpers.mockPrompt(modelGen, {
+    testhelpers.mockPrompt(modelGen, {
       name: 'Product'
     });
 
@@ -106,7 +107,7 @@ describe('loopback:model generator', function() {
 
   it('sets custom `base` option', function(done) {
     var modelGen = givenModelGenerator();
-    helpers.mockPrompt(modelGen, {
+    testhelpers.mockPrompt(modelGen, {
       name: 'Product',
       dataSource: 'rest',
       base: null,
@@ -132,7 +133,7 @@ describe('loopback:model generator', function() {
 
     it('should set dataSource to null', function(done) {
       var modelGen = givenModelGenerator();
-      helpers.mockPrompt(modelGen, {
+      testhelpers.mockPrompt(modelGen, {
         name: 'Product',
         plural: 'pds'
       });
@@ -154,7 +155,7 @@ describe('loopback:model generator', function() {
       }, function(err) {
         if (err) return done(err);
         var modelGen = givenModelGenerator();
-        helpers.mockPrompt(modelGen, {
+        testhelpers.mockPrompt(modelGen, {
           name: 'Review',
           plural: 'Reviews'
         });
@@ -179,7 +180,7 @@ describe('loopback:model generator', function() {
       }], function(err) {
         if (err) return done(err);
         var modelGen = givenModelGenerator();
-        helpers.mockPrompt(modelGen, {
+        testhelpers.mockPrompt(modelGen, {
           name: 'Review',
           plural: 'Reviews'
         });
@@ -194,11 +195,11 @@ describe('loopback:model generator', function() {
 
   });
 
-  function givenModelGenerator(modelArgs) {
-    var path = '../../model';
+  function givenModelGenerator() {
+    var path = ['../../model',
+      [testhelpers.createDummyGenerator(), 'loopback:property']];
     var name = 'loopback:model';
-    var deps = [ ['../../property', 'loopback:property'] ];
-    var gen = common.createGenerator(name, path, deps, modelArgs, {});
+    var gen = common.createGenerator(name, path);
     return gen;
   }
 

--- a/test/property.test.js
+++ b/test/property.test.js
@@ -11,6 +11,7 @@ var wsModels = require('loopback-workspace').models;
 var SANDBOX =  path.resolve(__dirname, 'sandbox');
 var expect = require('chai').expect;
 var common = require('./common');
+var testhelpers = require('yeoman-test');
 
 describe('loopback:property generator', function() {
   beforeEach(common.resetWorkspace);
@@ -37,7 +38,7 @@ describe('loopback:property generator', function() {
 
   it('adds an entry to common/models/{name}.json', function(done) {
     var propertyGenerator = givenPropertyGenerator();
-    helpers.mockPrompt(propertyGenerator, {
+    testhelpers.mockPrompt(propertyGenerator, {
       model: 'Car',
       name: 'isPreferred',
       customType: '', // temporary workaround for
@@ -64,7 +65,7 @@ describe('loopback:property generator', function() {
 
   it('creates a typed array', function(done) {
     var propertyGenerator = givenPropertyGenerator();
-    helpers.mockPrompt(propertyGenerator, {
+    testhelpers.mockPrompt(propertyGenerator, {
       model: 'Car',
       name: 'list',
       type: 'array',
@@ -85,7 +86,7 @@ describe('loopback:property generator', function() {
   
   it('creates a defaultFn: "now" on date fields if specified', function(done) {
     var propertyGenerator = givenPropertyGenerator();
-    helpers.mockPrompt(propertyGenerator, {
+    testhelpers.mockPrompt(propertyGenerator, {
       model: 'Car',
       name: 'created',
       type: 'date',
@@ -106,7 +107,7 @@ describe('loopback:property generator', function() {
 
   it('creates a defaultFn: "guid" on date fields if specified', function(done) {
     var propertyGenerator = givenPropertyGenerator();
-    helpers.mockPrompt(propertyGenerator, {
+    testhelpers.mockPrompt(propertyGenerator, {
       model: 'Car',
       name: 'uniqueId',
       type: 'string',

--- a/test/relations.test.js
+++ b/test/relations.test.js
@@ -11,6 +11,7 @@ var wsModels = require('loopback-workspace').models;
 var SANDBOX =  path.resolve(__dirname, 'sandbox');
 var expect = require('chai').expect;
 var common = require('./common');
+var testhelpers = require('yeoman-test');
 
 describe('loopback:relation generator', function() {
   beforeEach(common.resetWorkspace);
@@ -37,7 +38,7 @@ describe('loopback:relation generator', function() {
 
   it('adds an entry to common/models/{name}.json', function(done) {
     var relationGenerator = givenRelationGenerator();
-    helpers.mockPrompt(relationGenerator, {
+    testhelpers.mockPrompt(relationGenerator, {
       model: 'Car',
       toModel: 'Part',
       asPropertyName: 'parts',
@@ -60,7 +61,7 @@ describe('loopback:relation generator', function() {
 
   it('asks for custom model name', function(done) {
     var relationGenerator = givenRelationGenerator();
-    helpers.mockPrompt(relationGenerator, {
+    testhelpers.mockPrompt(relationGenerator, {
       model: 'Car',
       toModel: null,
       customToModel: 'Part',
@@ -84,7 +85,7 @@ describe('loopback:relation generator', function() {
 
   it('asks for through model name', function(done) {
     var relationGenerator = givenRelationGenerator();
-    helpers.mockPrompt(relationGenerator, {
+    testhelpers.mockPrompt(relationGenerator, {
       model: 'Car',
       toModel: 'Part',
       asPropertyName: 'parts',
@@ -110,7 +111,7 @@ describe('loopback:relation generator', function() {
 
   it('asks for custom through model name', function(done) {
     var relationGenerator = givenRelationGenerator();
-    helpers.mockPrompt(relationGenerator, {
+    testhelpers.mockPrompt(relationGenerator, {
       model: 'Car',
       toModel: 'Part',
       asPropertyName: 'parts',
@@ -139,7 +140,7 @@ describe('loopback:relation generator', function() {
   it('provides default property name based on target model for belongsTo',
     function(done) {
       var relationGenerator = givenRelationGenerator();
-      helpers.mockPrompt(relationGenerator, {
+      testhelpers.mockPrompt(relationGenerator, {
         model: 'Car',
         toModel: 'Part',
         type: 'belongsTo'
@@ -157,7 +158,7 @@ describe('loopback:relation generator', function() {
   it('provides default property name based on target model for hasMany',
     function(done) {
       var relationGenerator = givenRelationGenerator();
-      helpers.mockPrompt(relationGenerator, {
+      testhelpers.mockPrompt(relationGenerator, {
         model: 'Car',
         toModel: 'Part',
         type: 'hasMany'

--- a/test/remote-method.test.js
+++ b/test/remote-method.test.js
@@ -11,6 +11,7 @@ var wsModels = require('loopback-workspace').models;
 var SANDBOX =  path.resolve(__dirname, 'sandbox');
 var expect = require('chai').expect;
 var common = require('./common');
+var testhelpers = require('yeoman-test');
 
 describe('loopback:remote-method generator', function() {
   beforeEach(common.resetWorkspace);
@@ -37,7 +38,7 @@ describe('loopback:remote-method generator', function() {
 
   it('adds an entry to common/models/{name}.json', function(done) {
     var methodGenerator = givenMethodGenerator();
-    helpers.mockPrompt(methodGenerator, {
+    testhelpers.mockPrompt(methodGenerator, {
       model: 'Car',
       methodName: 'myRemote',
       isStatic: 'true',

--- a/test/swagger.test.js
+++ b/test/swagger.test.js
@@ -12,6 +12,7 @@ var path = require('path');
 var fs = require('fs');
 var expect = require('chai').expect;
 var common = require('./common');
+var testhelpers = require('yeoman-test');
 
 describe('loopback:swagger generator', function () {
   beforeEach(common.resetWorkspace);
@@ -27,7 +28,7 @@ describe('loopback:swagger generator', function () {
   it('creates and configures server only Pet model from swagger 2.0 spec',
     function (done) {
       var modelGen = givenModelGenerator();
-      helpers.mockPrompt(modelGen, {
+      testhelpers.mockPrompt(modelGen, {
         url: path.join(__dirname, 'swagger/pet-store-2.0.json'),
         modelSelections:
           ['swagger_v2_petstore', 'Category',
@@ -58,7 +59,7 @@ describe('loopback:swagger generator', function () {
   it('creates and configures server only Pet model from swagger 2.0 spec yml',
     function (done) {
       var modelGen = givenModelGenerator();
-      helpers.mockPrompt(modelGen, {
+      testhelpers.mockPrompt(modelGen, {
         url: path.join(__dirname, 'swagger/pet-store-2.0.yml'),
         modelSelections:
           ['swagger_v2_petstore', 'Category',
@@ -89,7 +90,7 @@ describe('loopback:swagger generator', function () {
   it('creates and configures server only note model from swagger 2.0 spec yaml',
     function (done) {
       var modelGen = givenModelGenerator();
-      helpers.mockPrompt(modelGen, {
+      testhelpers.mockPrompt(modelGen, {
         url: path.join(__dirname, 'swagger/demo4.yaml'),
         modelSelections:
           ['swagger_api', 'note'],
@@ -119,7 +120,7 @@ describe('loopback:swagger generator', function () {
   it('creates and configures server only Pet model from swagger 1.2 spec',
     function (done) {
       var modelGen = givenModelGenerator();
-      helpers.mockPrompt(modelGen, {
+      testhelpers.mockPrompt(modelGen, {
         url: path.join(__dirname, 'swagger/pet-store-1.2.json'),
         modelSelections: ['swagger_pet', 'Category', 'Pet', 'Tag'],
         dataSource: 'db'
@@ -145,11 +146,10 @@ describe('loopback:swagger generator', function () {
       });
     });
 
-  function givenModelGenerator(modelArgs) {
+  function givenModelGenerator() {
     var path = '../../swagger';
     var name = 'loopback:swagger';
-    var deps = [];
-    var gen = common.createGenerator(name, path, deps, modelArgs, {});
+    var gen = common.createGenerator(name, path);
     return gen;
   }
 


### PR DESCRIPTION
Fix broken unit test from latest dependency update in yeoman-generator. Switch to use yeoman-test instead of yeoman-generator test as its deprecated in the latest release.