### PR TITLE
fix/update-to-promise-support

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -4,6 +4,7 @@
 // License text available at https://opensource.org/licenses/MIT
 
 'use strict';
+global.Promise = require('bluebird');
 var assert = require('assert');
 var chalk = require('chalk');
 var yeoman = require('yeoman-generator');
@@ -98,20 +99,18 @@ exports.validateOptionalName = function (name) {
  * Check if relation has a different name from properties
  * @param {Object} modelDefinition The model which has the relation
  * @param {String} name The user input
- * @param {Function(String|Boolean)} Callback to receive the check result.
+ * @returns {String|Boolean} Return the check result.
  */
-exports.checkRelationName = function (modelDefinition, name, callback) {
-  modelDefinition.properties(function(err, list) {
-    if (err) callback(err);
-    var conflict = list.some(function(property) {
-      return property.name === name;
+exports.checkRelationName = function (modelDefinition, name) {
+  return modelDefinition.properties.getAsync()
+    .then(function(list) {
+      var conflict = list.some(function(property) {
+        return property.name === name;
+      });
+      return conflict?
+        'Same property name already exists: ' + name :
+        true;
     });
-    if (conflict) {
-      callback('Same property name already exists: ' + name);
-    } else {
-      callback(true);
-    }
-  });
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
   ],
   "dependencies": {
     "async": "^1.4.2",
+    "bluebird": "^3.1.1",
     "chalk": "^1.1.0",
     "debug": "^2.2.0",
     "inflection": "^1.7.1",

--- a/relation/index.js
+++ b/relation/index.js
@@ -120,7 +120,7 @@ module.exports = yeoman.generators.Base.extend({
         validate: function(value) {
           var isValid = checkPropertyName(value);
           if (isValid !== true) return isValid;
-          return checkRelationName(modelDef, value, this.async());
+          return checkRelationName(modelDef, value);
         }
       },
       {


### PR DESCRIPTION
Connect to strongloop/loopback#2292

Contains relation generator fix only.

`yeoman-environment` uses the latest `inquirer`, which depends on a new module `rx` that supports promise only. So we cannot use callback in function [`checkRelationName`](https://github.com/strongloop/generator-loopback/blob/master/relation/index.js#L123)

Please review. Thanks.