### PR TITLE
Fix failing relation name test

### DIFF
--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -12,6 +12,7 @@ var validateRequiredName = helpers.validateRequiredName;
 var checkRelationName = helpers.checkRelationName;
 require('chai').should();
 var expect = require('chai').expect;
+var promise = require('bluebird');
 
 describe('helpers', function() {
   describe('validateAppName()', function() {
@@ -113,7 +114,9 @@ function testRelationRejectsValue(modelDefinition, value) {
 
 function ModelDefinition(propertyList) {
   this.propertyList = propertyList;
-  this.properties = function(callback) {
-    callback(null, this.propertyList);
+  this.properties = {
+    getAsync: function() {
+      return promise.resolve(propertyList);
+    }
   };
 }


### PR DESCRIPTION
The tests were failing because there wasn't a `getAsync` method on the mocked out object