### PR TITLE
Fix model generator

### DIFF
--- a/model/index.js
+++ b/model/index.js
@@ -221,7 +221,9 @@ module.exports = yeoman.generators.Base.extend({
       {
         name: 'propertyName',
         message: 'Property name:',
-        validate: validateOptionalName
+        validate: function(value){
+          return validateOptionalName(value);
+        }
       }
     ];
     this.prompt(prompts, function(answers) {

--- a/relation/index.js
+++ b/relation/index.js
@@ -126,7 +126,9 @@ module.exports = yeoman.generators.Base.extend({
       {
         name: 'foreignKey',
         message: 'Optionally enter a custom foreign key:',
-        validate: validateOptionalName
+         validate: function(value){
+          return validateOptionalName(value);
+        }
       },
       {
         name: 'through',

--- a/remote-method/index.js
+++ b/remote-method/index.js
@@ -198,7 +198,9 @@ module.exports = yeoman.generators.Base.extend({
         name: 'acceptsArg',
         message: 'What is the name of this argument?',
         required: true,
-        validate: validateOptionalName
+        validate: function(value){
+          return validateOptionalName(value);
+        }
       }
     ];
     this.prompt(prompts, function(answers) {
@@ -292,7 +294,9 @@ module.exports = yeoman.generators.Base.extend({
         name: 'returnsArg',
         message: 'What is the name of this argument?',
         required: true,
-        validate: validateOptionalName
+        validate: function(value){
+          return validateOptionalName(value);
+        }
       }
     ];
     this.prompt(prompts, function(answers) {


### PR DESCRIPTION
A fix to https://github.com/strongloop/loopback/issues/2292#issuecomment-223397865

Model generator is broken due to the name check of property:

```
`? Enter the model name: Contact
? Select the data-source to attach undefined to: db (memory)
? Select model's base class PersistedModel
? Expose Contact via the REST API? Yes
? Custom plural form (used to build REST URL): 
? Common model or server only? common
Let's add some Contact properties now.

Enter an empty property name when done.
? Property name: 
>> Name cannot contain special characters [object Object]email
`
```

If we use 
[`validate: validateOptionalName](https://github.com/strongloop/generator-loopback/blob/master/model/index.js#L224)
to validate name, it will provide a second argument to the function `validateOptionalName`:
use console.log to show it
```
JSON.stringify(second arg): {}
second arg: [object Object]
```
So it refuse name that match [object Object]
.

Use 
```js
validate: function(value) {
  validateOptionalName(value);
}
```
instead  to fix it by forcing the second argument as undefined.