### PR TITLE
Add prompt for lbVersion

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -153,6 +153,23 @@ module.exports = yeoman.generators.Base.extend({
     });
   },
 
+  askForLBVersion: function() {
+    var cb = this.async();
+    var prompts = [{
+      name: 'loopbackVersion',
+      message: 'Which version of LoopBack would you like to use?',
+      type: 'list',
+      default: '2.x',
+      choices: ['2.x', '3.x']
+    }];
+
+    var self = this;
+    this.prompt(prompts, function(answers) {
+      self.options.loopbackVersion = answers.loopbackVersion;
+      cb();
+    });
+  },
+
   initWorkspace: actions.initWorkspace,
 
   detectExistingProject: function() {
@@ -173,6 +190,7 @@ module.exports = yeoman.generators.Base.extend({
       this.wsTemplate,
       this.appname,
       {
+        'loopbackVersion': this.options.loopbackVersion,
         'loopback-component-explorer': this.options.explorer !== false,
       },
       done

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "fs-extra": "^0.23.1",
     "jshint": "^2.8.0",
     "mocha": "^2.2.5",
+    "semver": "^5.1.0",
     "strong-cached-install": "^2.0.0"
   }
 }

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -7,6 +7,7 @@
 'use strict';
 var path = require('path');
 var yg = require('yeoman-generator');
+var semver = require('semver');
 var ygAssert = yg.assert;
 var helpers = yg.test;
 var SANDBOX =  path.resolve(__dirname, 'sandbox');
@@ -122,6 +123,38 @@ describe('loopback:app generator', function() {
       var compConfig = common.readJsonSync('server/component-config.json', {});
       expect(Object.keys(compConfig))
         .to.not.contain('loopback-component-explorer');
+      done();
+    });
+  });
+
+  it('scaffolds 3.x app when option.loopbackVersion is 3.x',
+    function(done) {
+    var gen = givenAppGenerator();
+
+    helpers.mockPrompt(gen, {
+      name: 'test-app',
+      template: 'api-server',
+      loopbackVersion: '3.x'
+    });
+    gen.run(function () {
+      var pkg = common.readJsonSync('package.json', {});
+      expect(semver.gtr('3.0.0', pkg.dependencies.loopback)).to.equal(false);
+      done();
+    });
+  });
+
+  it('scaffolds 2.x app when option.loopbackVersion is 2.x',
+    function(done) {
+    var gen = givenAppGenerator();
+
+    helpers.mockPrompt(gen, {
+      name: 'test-app',
+      template: 'api-server',
+      loopbackVersion: '2.x'
+    });
+    gen.run(function () {
+      var pkg = common.readJsonSync('package.json', {});
+      expect(semver.gtr('3.0.0', pkg.dependencies.loopback)).to.equal(true);
       done();
     });
   });


### PR DESCRIPTION
Connect to strongloop/loopback#2344

Add a new prompt called `loopbackVersion` and pass it into [`createFromTemplate`](https://github.com/strongloop/generator-loopback/blob/master/app/index.js#L172)

```
 {
        name: 'loopbackVersion',
        message: 'Which version of loopback do you want to install?',
        default: 2.x,
        choices: ['2.x', '3.x'],
}
```