### PR TITLE
Fix "undefined" model name

### DIFF
--- a/model/index.js
+++ b/model/index.js
@@ -75,6 +75,7 @@ module.exports = yeoman.generators.Base.extend({
 
     this.prompt(prompts, function(props) {
       this.name = props.name;
+      this.displayName = chalk.yellow(this.name);
       done();
     }.bind(this));
 


### PR DESCRIPTION
A small bug I noticed when I tried to create a model ...

Before:
![before](https://cloud.githubusercontent.com/assets/2675698/15862296/3e45c73a-2c9d-11e6-9991-4bcd959d3aaf.png)

After:
![after](https://cloud.githubusercontent.com/assets/2675698/15862313/48424376-2c9d-11e6-8781-8802fbd642b2.png)

