### PR TITLE
Support custom connector

### DIFF
--- a/datasource/index.js
+++ b/datasource/index.js
@@ -198,10 +198,13 @@ module.exports = yeoman.generators.Base.extend({
 
   installConnector: function() {
     var connector = this.availableConnectors[this.connector];
-    var pkg = connector.package;
-    if (!pkg) return;
-
-    var npmModule = pkg.name;
+    var pkg = {};
+    if (connector) {
+      pkg = connector.package;
+      if (!pkg) return;
+    }
+    
+    var npmModule = pkg.name || this.connector;
     if (pkg.version) {
       npmModule += '@' + pkg.version;
     }
@@ -244,6 +247,17 @@ module.exports = yeoman.generators.Base.extend({
       helpers.reportValidationError(err, this.log);
       return done(err);
     }.bind(this));
+  },
+
+  printAddConfigForCustomConnector: function() {
+    var connector = this.connector;
+    if (!this.availableConnectors[connector]) {
+      this.log('Please manually add config for your custom connector ' +
+        connector +
+        ' in server/datasources.json');
+    } else {
+      return;
+    }
   },
 
   saveProject: actions.saveProject

--- a/test/datasource.test.js
+++ b/test/datasource.test.js
@@ -80,6 +80,24 @@ describe('loopback:datasource generator', function() {
     });
   });
 
+  it('should support custom connector', function(done) {
+    var modelGen = givenDataSourceGenerator();
+    helpers.mockPrompt(modelGen, {
+      name: 'test-custom',
+      customConnector: 'lodash',
+      connector: 'other'
+    });
+
+    modelGen.run(function() {
+      var pkg = fs.readFileSync(
+        path.join(SANDBOX, 'package.json'), 'UTF-8');
+      pkg = JSON.parse(pkg);
+      /* jshint -W030 */
+      expect(pkg.dependencies.lodash).to.exist;
+      done();
+    });
+  });
+
   it('should support object/array settings', function(done) {
     var restOptions = {
       headers: {


### PR DESCRIPTION
Connect to strongloop/loopback#2265

Now when we choose a custom connector that not included in available connectors, it returns error.
This pr is created for supporting custom connector, and print a message to remind user manually add config then.
