### PR TITLE
app: describe stability of 2.x/3.x versions

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -148,13 +148,29 @@ module.exports = yeoman.Base.extend({
     }.bind(this));
   },
 
+  fetchLoopBackVersions: function() {
+    var done = this.async();
+    var self = this;
+    Workspace.getAvailableLBVersions(function(err, versionsMap) {
+      if (err) return done(err);
+      var versionNames = Object.keys(versionsMap);
+      self.availableLBVersions = versionNames.map(function(version) {
+        return {
+          name: version + ' (' + versionsMap[version].description + ')',
+          value: version,
+        };
+      });
+      done();
+    });
+  },
+
   askForLBVersion: function() {
     var prompts = [{
       name: 'loopbackVersion',
       message: 'Which version of LoopBack would you like to use?',
       type: 'list',
       default: '2.x',
-      choices: ['2.x', '3.x'],
+      choices: this.availableLBVersions,
     }];
 
     var self = this;


### PR DESCRIPTION
Improve the prompt for LoopBack version to tell the user what level of stability to expect from each version range.

I feel the current prompt does not give enough information to the user to make a good decision:

```
? Which version of LoopBack would you like to use? (Use arrow keys)
❯ 2.x
  3.x
```

Here is the new prompt:

```
? Which version of LoopBack would you like to use? (Use arrow keys)
❯ 2.x (stable)
  3.x (pre-release, alpha quality)
```

@jannyHou please review the implementation details
@ritch @crandmck @richardpringle please take a look at the additional text we are printing now and let me know how can we improve it.