### PR TITLE
Apply filter on templates

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -135,6 +135,25 @@ module.exports = yeoman.generators.Base.extend({
 
   configureDestinationDir: actions.configureDestinationDir,
 
+  askForLBVersion: function() {
+    var cb = this.async();
+    var prompts = [{
+      name: 'loopbackVersion',
+      message: 'Which version of LoopBack would you like to use?',
+      type: 'list',
+      default: '2.x',
+      choices: ['2.x', '3.x']
+    }];
+
+    var self = this;
+    this.prompt(prompts, function(answers) {
+      self.options.loopbackVersion = answers.loopbackVersion;
+      cb();
+    });
+  },
+  
+  applyTemplateFilter: actions.templateFilter,
+
   askForTemplate: function() {
     var cb = this.async();
     var prompts = [{
@@ -149,23 +168,6 @@ module.exports = yeoman.generators.Base.extend({
     this.prompt(prompts, function(answers) {
       // Do NOT use name template as it's a method in the base class
       self.wsTemplate = answers.wsTemplate;
-      cb();
-    });
-  },
-
-  askForLBVersion: function() {
-    var cb = this.async();
-    var prompts = [{
-      name: 'loopbackVersion',
-      message: 'Which version of LoopBack would you like to use?',
-      type: 'list',
-      default: '2.x',
-      choices: ['2.x', '3.x']
-    }];
-
-    var self = this;
-    this.prompt(prompts, function(answers) {
-      self.options.loopbackVersion = answers.loopbackVersion;
       cb();
     });
   },

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -188,3 +188,13 @@ actions.addNullDataSourceItem = function() {
     value: null
   });
 };
+
+actions.templateFilter = function() {
+  if (this.options.loopbackVersion === '2.x') {
+    for (var template in this.templates) {
+      if (this.templates[template].name.includes('hello-world')) {
+        delete this.templates[template];
+      }
+    }
+  }
+};

--- a/lib/actions.js
+++ b/lib/actions.js
@@ -192,7 +192,7 @@ actions.addNullDataSourceItem = function() {
 actions.templateFilter = function() {
   if (this.options.loopbackVersion === '2.x') {
     for (var template in this.templates) {
-      if (this.templates[template].name.includes('hello-world')) {
+      if (this.templates[template].name.indexOf('hello-world') > -1) {
         delete this.templates[template];
       }
     }


### PR DESCRIPTION
Connect to strongloop-internal/scrum-loopback#926

Move the version 2/3.x selection before the template prompt and filter based on it.
After controller adding to `hello-world` template, it will not support 2.x, so I delete the choice of `hello-world` when 2.x is applied.