### PR TITLE
Add filter [WIP]

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -132,6 +132,32 @@ module.exports = yeoman.Base.extend({
 
   configureDestinationDir: actions.configureDestinationDir,
 
+  askForLBVersion: function() {
+    var availableLBVersions = Object.keys(Workspace.getAvailableLBVersions());
+    var prompts = [{
+      name: 'loopbackVersion',
+      message: 'Which version of LoopBack would you like to use?',
+      type: 'list',
+      default: '2.x',
+      choices: availableLBVersions
+    }];
+
+    var self = this;
+    return this.prompt(prompts).then(function(answers) {
+      self.options.loopbackVersion = answers.loopbackVersion;
+    }.bind(this));
+  },
+
+  applyFilterOnTemplate: function() {
+    var LBVersion = this.options.loopbackVersion;
+    for(var template in this.templates) {
+      if (this.templates[template].supportedLBVersions
+        .indexOf(LBVersion) === -1) {
+        delete this.templates[template];
+      }
+    }
+  },
+
   askForTemplate: function() {
     var prompts = [{
       name: 'wsTemplate',
@@ -145,21 +171,6 @@ module.exports = yeoman.Base.extend({
     return this.prompt(prompts).then(function(answers) {
       // Do NOT use name template as it's a method in the base class
       self.wsTemplate = answers.wsTemplate;
-    }.bind(this));
-  },
-
-  askForLBVersion: function() {
-    var prompts = [{
-      name: 'loopbackVersion',
-      message: 'Which version of LoopBack would you like to use?',
-      type: 'list',
-      default: '2.x',
-      choices: ['2.x', '3.x']
-    }];
-
-    var self = this;
-    return this.prompt(prompts).then(function(answers) {
-      self.options.loopbackVersion = answers.loopbackVersion;
     }.bind(this));
   },
 

--- a/app/index.js
+++ b/app/index.js
@@ -133,7 +133,17 @@ module.exports = yeoman.Base.extend({
   configureDestinationDir: actions.configureDestinationDir,
 
   askForLBVersion: function() {
-    var availableLBVersions = Object.keys(Workspace.getAvailableLBVersions());
+    var cb = this.async();
+
+    var availableLBVersions;
+    Workspace.getAvailableLBVersions(function(err, LBVersions) {
+      if (err) {
+        return cb(err);
+      } else {
+        availableLBVersions = Object.keys(LBVersions);
+      }
+    });
+
     var prompts = [{
       name: 'loopbackVersion',
       message: 'Which version of LoopBack would you like to use?',


### PR DESCRIPTION
WIP
Connect to strongloop-internal/scrum-loopback#926

Related proposal: https://github.com/strongloop/generator-loopback/pull/207#issuecomment-227672375

In this pr:
[1]. I moved the loopbackVersion prompt before template, and get available LBVersions from loopback-workspace: [Workspace.getAvailableLBVersions()](https://github.com/strongloop/loopback-workspace/pull/290/files?diff=unified#diff-7bbb877b22354ec23e89bcd8cf629ed5R58)

[2]. I added a filter to choose templates based on it's supported LBVersion.

The test cases are failing now since change in lb-workspace is not merged yet.