### PR TITLE
Replace-callback-with-promise

### DIFF
--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -124,20 +124,18 @@ function validateValue(name, unallowedCharacters) {
  * Check if relation has a different name from properties
  * @param {Object} modelDefinition The model which has the relation
  * @param {String} name The user input
- * @param {Function(String|Boolean)} Callback to receive the check result.
+ * @returns {String|Boolean} Return the check result.
  */
-exports.checkRelationName = function (modelDefinition, name, callback) {
-  modelDefinition.properties(function(err, list) {
-    if (err) callback(err);
-    var conflict = list.some(function(property) {
-      return property.name === name;
+exports.checkRelationName = function (modelDefinition, name) {
+  return modelDefinition.properties.getAsync()
+    .then(function(list) {
+      var conflict = list.some(function(property) {
+        return property.name === name;
+      });
+      return conflict?
+        'Same property name already exists: ' + name :
+        true;
     });
-    if (conflict) {
-      callback('Same property name already exists: ' + name);
-    } else {
-      callback(true);
-    }
-  });
 };
 
 /**

--- a/package.json
+++ b/package.json
@@ -37,6 +37,7 @@
     "yosay": "^1.0.5"
   },
   "devDependencies": {
+    "bluebird": "^3.1.1",
     "chai": "^3.2.0",
     "fs-extra": "^0.23.1",
     "jshint": "^2.8.0",

--- a/relation/index.js
+++ b/relation/index.js
@@ -117,7 +117,7 @@ module.exports = yeoman.Base.extend({
         validate: function(value) {
           var isValid = checkPropertyName(value);
           if (isValid !== true) return isValid;
-          return checkRelationName(modelDef, value, this.async());
+          return checkRelationName(modelDef, value);
         }
       },
       {

--- a/test/helpers.test.js
+++ b/test/helpers.test.js
@@ -13,6 +13,7 @@ var checkRelationName = helpers.checkRelationName;
 var validateRemoteMethodName = helpers.validateRemoteMethodName;
 require('chai').should();
 var expect = require('chai').expect;
+var promise = require('bluebird');
 
 describe('helpers', function() {
   describe('validateAppName()', function() {
@@ -144,7 +145,9 @@ function testRelationRejectsValue(modelDefinition, value) {
 
 function ModelDefinition(propertyList) {
   this.propertyList = propertyList;
-  this.properties = function(callback) {
-    callback(null, this.propertyList);
+  this.properties = {
+    getAsync: function() {
+      return promise.resolve(propertyList);
+    }
   };
 }


### PR DESCRIPTION
Connect to strongloop/loopback#2505

Relation Name Check has a compatible problem with the latest yeoman generator.
Error details see:
```
jisoos-mbp:ji jisoolee$ apic loopback:relation
? Select the model to create the relationship from: Message
? Relation type: has many
? Choose a model to create a relationship with: Message
? Enter the property name for the relation: (messages) xyzErrorError: undefined
```

I believe it's caused by missing strongloop/generator-loopback@ba69e64
I apply that commit and the related test case here to fix it.