### PR TITLE
Always allow properties with no default value

### DIFF
--- a/property/index.js
+++ b/property/index.js
@@ -152,11 +152,9 @@ module.exports = yeoman.Base.extend({
         this.propDefinition.required = Boolean(answers.required);
       }
 
-      if (this.propDefinition.required && answers.defaultValue === '') {
-        this.log(g.f('Warning: please enter the %s property again. ' +
-            'The default value provided "%s" is not valid for type: %s',
-            this.name, answers.defaultValue, this.type));
-        return this.askForParameters();
+      if (answers.defaultValue === '') {
+        answers.defaultValue = null;
+        return;
       }
 
       try {


### PR DESCRIPTION
Revert the behaviour change introduced by 950c8b, as it was confusing users.

I am intentionally not including a unit test, as I am not able to create a failing one. It seems that the mock prompt is converting empty strings to nulls under the hood, which bypasses the original check `if (required && defaultValue === '')`.

Connect to #213 

@0candy or @jannyHou: please review