### PR TITLE
property: Avoid casting invalid date into `null`

### DIFF
--- a/intl/en/messages.json
+++ b/intl/en/messages.json
@@ -162,5 +162,6 @@
   "c0483dd8d23458307540203286e78c54": "Select models to be generated:",
   "d81c3f76c041316e683d0d286e98eefd": "Creating model definition for {0}...",
   "e2f5703e707131e5d51136a8ebc19730": "Updating model definition for {0}...",
-  "e6404ed6a215776c8f58a16fd5d03146": "Select the data-source to attach models to:"
+  "e6404ed6a215776c8f58a16fd5d03146": "Select the data-source to attach models to:",
+  "52c74c58f38c73d2cfc2ac977f3301f9": "Invalid default Date value: {0}"
 }

--- a/property/index.js
+++ b/property/index.js
@@ -250,6 +250,9 @@ function castToDate(value) {
   } else {
     dateValue = new Date(value);
   }
+  if (isNaN(dateValue.getTime())) {
+    throw Error(g.f('Invalid default Date value: %s', value));
+  }
   return dateValue;
 }
 


### PR DESCRIPTION
fixes https://github.com/strongloop/generator-loopback/issues/224
avoids scenario where generator ends up with `default: null` in date objects as they are not valid dates, it will now throw error which prompts user to enter the property again