### PR TITLE
Do not prompt for properties for KeyValueModel

### DIFF
--- a/model/index.js
+++ b/model/index.js
@@ -207,11 +207,18 @@ module.exports = yeoman.Base.extend({
   },
 
   delim: function() {
+    if (this.base === 'KeyValueModel')
+      return;
+
     this.log(g.f('Let\'s add some %s properties now.\n', this.displayName));
   },
 
   property: function() {
     var done = this.async();
+
+    if (this.base === 'KeyValueModel')
+      return;
+
     this.log(g.f('Enter an empty property name when done.'));
     var prompts = [
       {


### PR DESCRIPTION
Do not prompt for properties when running `slc loopback:model` and choosing `KeyValueModel` as the base model.

Connect to https://github.com/strongloop-internal/scrum-loopback/issues/1074

@bajtos PTAL