### PR TITLE
Add missing space in globalize help file

### DIFF
--- a/lib/help.js
+++ b/lib/help.js
@@ -22,7 +22,7 @@ exports.customHelp = function(generator, usageFilePath, cmd) {
   // Build usage
   var helpStr = [
     g.f('Usage:'),
-    ' ' + usageBuild(generator),
+    '  ' + usageBuild(generator),
     '',
   ];
 

--- a/test/fixtures/help-texts/loopback_acl_help.txt
+++ b/test/fixtures/help-texts/loopback_acl_help.txt
@@ -1,5 +1,5 @@
 Usage:
- slc loopback:acl [options] 
+  slc loopback:acl [options] 
 
 Options:
   -h,   --help          # Print the generator's options and usage

--- a/test/fixtures/help-texts/loopback_app_help.txt
+++ b/test/fixtures/help-texts/loopback_app_help.txt
@@ -1,5 +1,5 @@
 Usage:
- slc loopback:app [options] [<name>]
+  slc loopback:app [options] [<name>]
 
 Options:
   -h,   --help             # Print the generator's options and usage

--- a/test/fixtures/help-texts/loopback_boot-script_help.txt
+++ b/test/fixtures/help-texts/loopback_boot-script_help.txt
@@ -1,5 +1,5 @@
 Usage:
- slc loopback:boot-script [options] [<name>]
+  slc loopback:boot-script [options] [<name>]
 
 Options:
   -h,   --help          # Print the generator's options and usage

--- a/test/fixtures/help-texts/loopback_datasource_help.txt
+++ b/test/fixtures/help-texts/loopback_datasource_help.txt
@@ -1,5 +1,5 @@
 Usage:
- slc loopback:datasource [options] [<name>]
+  slc loopback:datasource [options] [<name>]
 
 Options:
   -h,   --help          # Print the generator's options and usage

--- a/test/fixtures/help-texts/loopback_export-api-def_help.txt
+++ b/test/fixtures/help-texts/loopback_export-api-def_help.txt
@@ -1,5 +1,5 @@
 Usage:
- slc loopback:export-api-def [options] 
+  slc loopback:export-api-def [options] 
 
 Options:
   -h,   --help          # Print the generator's options and usage

--- a/test/fixtures/help-texts/loopback_middleware_help.txt
+++ b/test/fixtures/help-texts/loopback_middleware_help.txt
@@ -1,5 +1,5 @@
 Usage:
- slc loopback:middleware [options] [<name>]
+  slc loopback:middleware [options] [<name>]
 
 Options:
   -h,   --help          # Print the generator's options and usage

--- a/test/fixtures/help-texts/loopback_model_help.txt
+++ b/test/fixtures/help-texts/loopback_model_help.txt
@@ -1,5 +1,5 @@
 Usage:
- slc loopback:model [options] [<name>]
+  slc loopback:model [options] [<name>]
 
 Options:
   -h,   --help          # Print the generator's options and usage

--- a/test/fixtures/help-texts/loopback_property_help.txt
+++ b/test/fixtures/help-texts/loopback_property_help.txt
@@ -1,5 +1,5 @@
 Usage:
- slc loopback:property [options] 
+  slc loopback:property [options] 
 
 Options:
   -h,   --help          # Print the generator's options and usage

--- a/test/fixtures/help-texts/loopback_relation_help.txt
+++ b/test/fixtures/help-texts/loopback_relation_help.txt
@@ -1,5 +1,5 @@
 Usage:
- slc loopback:relation [options] 
+  slc loopback:relation [options] 
 
 Options:
   -h,   --help          # Print the generator's options and usage

--- a/test/fixtures/help-texts/loopback_remote-method_help.txt
+++ b/test/fixtures/help-texts/loopback_remote-method_help.txt
@@ -1,5 +1,5 @@
 Usage:
- slc loopback:remote-method [options] [<modelName>] [<methodName>]
+  slc loopback:remote-method [options] [<modelName>] [<methodName>]
 
 Options:
   -h,   --help          # Print the generator's options and usage

--- a/test/fixtures/help-texts/loopback_swagger_help.txt
+++ b/test/fixtures/help-texts/loopback_swagger_help.txt
@@ -1,5 +1,5 @@
 Usage:
- slc loopback:swagger [options] [<url>]
+  slc loopback:swagger [options] [<url>]
 
 Options:
   -h,   --help          # Print the generator's options and usage


### PR DESCRIPTION
Connect to strongloop/generator-loopback#227

Compared with the old one, the new generated help texts miss a space.
Fixing it in this pr.
Details see: https://github.com/strongloop/generator-loopback/issues/227#issuecomment-256066398