### PR TITLE
Start 2.x + drop support for Node v0.10/v0.12

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,9 @@
 sudo: false
 language: node_js
 node_js:
-  - '0.10'
+  - 4
+  - 6
+  - 7
 before_install:
   - currentfolder=${PWD##*/}
   - if [ "$currentfolder" != 'generator-loopback' ]; then cd .. && eval "mv $currentfolder generator-loopback" && cd generator-loopback; fi

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "generator-loopback",
-  "version": "1.25.0",
+  "version": "2.0.0-alpha.1",
   "description": "Yeoman generator for LoopBack",
   "license": "MIT",
   "main": "app/index.js",

--- a/package.json
+++ b/package.json
@@ -11,7 +11,7 @@
     "url": "http://strongloop.com/"
   },
   "engines": {
-    "node": ">=0.10.0"
+    "node": ">=4"
   },
   "scripts": {
     "test": "mocha -R spec --timeout 60000",


### PR DESCRIPTION
Connect to strongloop/loopback#2807
Connect to strongloop-internal/scrum-loopback#1188

Note that I am intentionally picking 2.x as the next major version, because generator-loopback is not used by LoopBack applications and therefore there is no need to associate its major version number with LoopBack's major version. Also since we are in the middle of refactoring loopback-workspace, I expect there will be a new major version of generator-loopback coming soon.

cc @strongloop/loopback-dev @ritch @superkhau @jannyHou 