### PR TITLE
Always require lib/globalize in tests

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,7 @@
   },
   "scripts": {
     "lint": "eslint --ignore-path .gitignore .",
-    "test": "mocha -R spec --timeout 60000",
+    "test": "mocha",
     "posttest": "npm run lint"
   },
   "keywords": [

--- a/test/acl.test.js
+++ b/test/acl.test.js
@@ -6,7 +6,6 @@
 /*global describe, beforeEach, afterEach, it */
 'use strict';
 var path = require('path');
-require('../lib/globalize');
 
 var helpers = require('yeoman-test');
 var wsModels = require('loopback-workspace').models;

--- a/test/mocha.opts
+++ b/test/mocha.opts
@@ -1,0 +1,3 @@
+--require lib/globalize
+--reporter spec
+--timeout 60000


### PR DESCRIPTION
Add "test/mocha.opts" file specifying that "lib/globalize" should be loaded before starting any tests.

This is important to allow usage like `mocha test/help.test.js`.

The current workaround, where the first test file "test/acl.test.js" was initializing strong-globalize, was not sufficient.

Now that we have "test/mocha.opts", this patch also moves CLI flags from package.json's "test" script into this file.