### PR TITLE
Add support for SLC_COMMAND="loopback-cli"

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -54,12 +54,20 @@ module.exports = yeoman.Base.extend({
 
   help: function() {
     var msgs = [helpText.customHelp(this, 'loopback_app_usage.txt')];
-    msgs.push(g.f('Available generators: \n\n  '));
-    msgs.push(Object.keys(this.options.env.getGeneratorsMeta())
+
+    var list = Object.keys(this.options.env.getGeneratorsMeta())
       .filter(function(name) {
         return name.indexOf('loopback:') !== -1;
-      }).join('\n  '));
-    return msgs.join('');
+      });
+    if (helpers.getCommandName() === 'loopback-cli') {
+      list = list.map(name => name.replace(/^loopback:/, 'lb '));
+      msgs.push(g.f('\nAvailable commands:\n\n'));
+    } else {
+      msgs.push(g.f('\nAvailable generators:\n\n'));
+    }
+
+    msgs.push(list.map(it => '  ' + it).join('\n'));
+    return msgs.join('') + '\n';
   },
 
   injectWorkspaceCopyRecursive: function() {
@@ -253,7 +261,10 @@ module.exports = yeoman.Base.extend({
       this.log();
     } else {
       this.log(g.f('  Create a model in your app'));
-      this.log(chalk.green('    $ ' + cmd + ' loopback:model'));
+      if (cmd === 'loopback-cli')
+        this.log(chalk.green('    $ lb model'));
+      else
+        this.log(chalk.green('    $ ' + cmd + ' loopback:model'));
       this.log();
       this.log(g.f('  Run the app'));
       this.log(chalk.green('    $ node .'));

--- a/lib/help.js
+++ b/lib/help.js
@@ -82,11 +82,11 @@ function usageBuild(generator) {
   var args = '';
 
   if (generator._arguments.length) {
-    args = generator._arguments.map(formatArg).join(' ');
+    args = ' ' + generator._arguments.map(formatArg).join(' ');
   }
 
   name = name.replace(/^yeoman:/, '');
-  var out = 'yo' + name + ' ' + options + ' ' + args;
+  var out = 'yo' + name + ' ' + options + args;
 
   if (generator.description) {
     out += '\n\n' + generator.description;

--- a/lib/help.js
+++ b/lib/help.js
@@ -45,12 +45,19 @@ exports.customHelp = function(generator, usageFilePath, cmd) {
   }
 
   // Append USAGE file if any
-  var exists = g.f(usageFilePath);
-  if (exists) {
-    helpStr.push(exists);
+  var usageText = g.f(usageFilePath);
+  if (usageText !== usageFilePath) {
+    helpStr.push(usageText);
   }
 
   helpStr = helpStr.join('\n');
+
+  if (command === 'loopback-cli') {
+    return helpStr
+      .replace(/ (yo|slc) loopback:/g, ' lb ')
+      .replace(/ (yo|slc) loopback/g, ' lb');
+  }
+
   return helpStr.replace(/ yo | slc /g, ' ' + command + ' ');
 };
 

--- a/lib/helpers.js
+++ b/lib/helpers.js
@@ -148,6 +148,8 @@ exports.getCommandName = function() {
   var command = 'yo';
   if (process.env.SLC_COMMAND === 'apic') {
     command = process.env.SLC_COMMAND;
+  } else if (process.env.SLC_COMMAND === 'loopback-cli') {
+    command = 'loopback-cli';
   } else if (process.env.SLC_COMMAND) {
     // to preserve condition treating `process.env.SLC_COMMAND` as boolean
     // cannot just use process.env.SLC_COMMAND as command due to regression

--- a/test/fixtures/help-texts/loopback_acl_help.txt
+++ b/test/fixtures/help-texts/loopback_acl_help.txt
@@ -1,5 +1,5 @@
 Usage:
-  slc loopback:acl [options] 
+  slc loopback:acl [options]
 
 Options:
   -h,   --help          # Print the generator's options and usage

--- a/test/fixtures/help-texts/loopback_app_help.txt
+++ b/test/fixtures/help-texts/loopback_app_help.txt
@@ -29,6 +29,7 @@ Example:
     server/config.json: Machine-editable app configuration.
     server/datasources.json: Definition of data sources.
     server/model-config.json: Model configuration.
-Available generators: 
+
+Available generators:
 
   loopback:app

--- a/test/fixtures/help-texts/loopback_export-api-def_help.txt
+++ b/test/fixtures/help-texts/loopback_export-api-def_help.txt
@@ -1,5 +1,5 @@
 Usage:
-  slc loopback:export-api-def [options] 
+  slc loopback:export-api-def [options]
 
 Options:
   -h,   --help          # Print the generator's options and usage

--- a/test/fixtures/help-texts/loopback_property_help.txt
+++ b/test/fixtures/help-texts/loopback_property_help.txt
@@ -1,5 +1,5 @@
 Usage:
-  slc loopback:property [options] 
+  slc loopback:property [options]
 
 Options:
   -h,   --help          # Print the generator's options and usage

--- a/test/fixtures/help-texts/loopback_relation_help.txt
+++ b/test/fixtures/help-texts/loopback_relation_help.txt
@@ -1,5 +1,5 @@
 Usage:
-  slc loopback:relation [options] 
+  slc loopback:relation [options]
 
 Options:
   -h,   --help          # Print the generator's options and usage

--- a/test/help.test.js
+++ b/test/help.test.js
@@ -5,6 +5,7 @@
 
 /*global describe, beforeEach, it */
 'use strict';
+var debug = require('debug')('test');
 var fs = require('fs');
 var path = require('path');
 var assert = require('assert');
@@ -44,6 +45,24 @@ describe('loopback generator help', function() {
       throw err;
     }
     process.env.SLC_COMMAND = undefined;
+  });
+
+  it('prints help message with lb if invoked from loopback-cli', function() {
+    process.env.SLC_COMMAND = 'loopback-cli';
+    var gen = givenGenerator('app', ['--help']);
+    var helpText = gen.help();
+    debug('--HELP TEXT--\n', helpText);
+    assert(helpText.indexOf(' lb ') !== -1,
+      '"lb" should be used');
+    assert(helpText.indexOf('Available commands') !== -1,
+      '"Available commands" should be used');
+
+    assert(helpText.indexOf(' slc ') === -1,
+      '"slc" should not be present');
+    assert(helpText.indexOf(' yo ') === -1,
+      '"yo" should not be present');
+    assert(helpText.indexOf('Available generators') === -1,
+      '"Available generators" should not be present');
   });
 
   describe('prints right help message for each generator', function() {


### PR DESCRIPTION
In order to support the upcoming tool `loopback-cli`, we need to modify generator-loopback to recognize the new wrapper. This time it's more tricky, because we are not only replacing `yo` with e.g. `slc`, but also dropping `loopback:` prefix from generator names.

```
lb model -> yo loopback:model
```

Connect to strongloop-internal/scrum-loopback#1028