### PR TITLE
New options

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -31,6 +31,11 @@ module.exports = yeoman.Base.extend({
       type: String,
     });
 
+    this.option('skip-greet', {
+      desc: g.f('Do not show greet message.'),
+      type: Boolean,
+    });
+
     this.option('skip-install', {
       desc: g.f('Do not install npm dependencies.'),
       type: Boolean,
@@ -49,6 +54,7 @@ module.exports = yeoman.Base.extend({
   },
 
   greet: function() {
+    if (this.options.skipGreet) return;
     this.log(yosay(g.f('Let\'s create a {{LoopBack}} application!')));
   },
 
@@ -116,6 +122,8 @@ module.exports = yeoman.Base.extend({
   },
 
   askForProjectName: function() {
+    if (this.options.appname) return;
+
     if (this.options.nested && this.name) {
       this.appname = this.name;
       return;
@@ -161,6 +169,8 @@ module.exports = yeoman.Base.extend({
   },
 
   askForLBVersion: function() {
+    if (this.options.loopbackVersion) return;
+
     var prompts = [{
       name: 'loopbackVersion',
       message: g.f('Which version of {{LoopBack}} would you like to use?'),
@@ -185,6 +195,8 @@ module.exports = yeoman.Base.extend({
   },
 
   askForTemplate: function() {
+    if (this.options.wsTemplate) return;
+
     var prompts = [{
       name: 'wsTemplate',
       message: g.f('What kind of application do you have in mind?'),

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -141,9 +141,42 @@ describe('loopback:app generator', function() {
       });
     });
 
-  it('scaffolds 2.x app when option.loopbackVersion is 2.x',
+  it('scaffolds 3.x app when the supplied option loopbackVersion is 3.x',
     function(done) {
       var gen = givenAppGenerator();
+      gen.options.loopbackVersion = '3.x';
+
+      helpers.mockPrompt(gen, {
+        name: 'test-app',
+        template: 'api-server',
+      });
+      gen.run(function() {
+        var pkg = common.readJsonSync('package.json', {});
+        expect(semver.gtr('3.0.0', pkg.dependencies.loopback)).to.equal(false);
+        done();
+      });
+    });
+
+  it('scaffolds 2.x app when options.loopbackVersion is 2.x',
+    function(done) {
+      var gen = givenAppGenerator();
+      gen.options.loopbackVersion = '2.x';
+
+      helpers.mockPrompt(gen, {
+        name: 'test-app',
+        template: 'api-server',
+        loopbackVersion: '2.x',
+      });
+      gen.run(function() {
+        var pkg = common.readJsonSync('package.json', {});
+        expect(semver.gtr('3.0.0', pkg.dependencies.loopback)).to.equal(true);
+        done();
+      });
+    });
+
+  it('scaffolds 2.x app when the supplied option loopbackVersion is 2.x',
+    function(done) {
+      var gen = givenAppGenerator(null,{"loopbackVersion": "3.x"});
 
       helpers.mockPrompt(gen, {
         name: 'test-app',


### PR DESCRIPTION
### Description

This PR adds extra options to the generator in order to skip certain prompts. If you supply `wsTemplate`, `loopbackVersion`, or `appname` then the prompts will not be shown. In addition, if you supply `skipGreet` then the initial greeting will not be shown


#### Related issues
- None
### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
