### PR TITLE
Update default LB version to 3.x

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -165,7 +165,7 @@ module.exports = yeoman.Base.extend({
       name: 'loopbackVersion',
       message: g.f('Which version of {{LoopBack}} would you like to use?'),
       type: 'list',
-      default: '2.x',
+      default: '3.x',
       choices: this.availableLBVersions,
     }];
 


### PR DESCRIPTION
The generator still defaults to version 2.x rather than the current version 3.x