### PR TITLE
Export the version of workspace we are using

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -289,3 +289,5 @@ module.exports = yeoman.Base.extend({
 // Export it for strong-cli to use
 module.exports._package = pkg.name + ': ' + pkg.version;
 module.exports._yeoman = yeoman;
+module.exports.workspaceVersion =
+  require('loopback-workspace/package.json').version;

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -157,6 +157,12 @@ describe('loopback:app generator', function() {
       });
     });
 
+  it('exports workspace version', () => {
+    const mainProps = Object.assign({}, require('../'));
+    expect(mainProps).to.have.property('workspaceVersion',
+      require('loopback-workspace/package.json').version);
+  });
+
   function givenAppGenerator(modelArgs) {
     var name = 'loopback:app';
     var path = '../../app';


### PR DESCRIPTION
### Description

Export the version of workspace we are using to allow CLI tools to include workspace version in `--version` output.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- Required by https://github.com/strongloop/loopback-cli/pull/25

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
