### PR TITLE
Integrate datasource with lb soap feature

### DIFF
--- a/lib/actions.js
+++ b/lib/actions.js
@@ -157,6 +157,7 @@ actions.loadDataSources = function() {
         name: ds.name + ' (' + ds.connector + ')',
         value: ds.name,
         _connector: ds.connector,
+        data: ds.__data,
       };
     });
 

--- a/soap/README.md
+++ b/soap/README.md
@@ -1,27 +1,8 @@
-# loopback-soap
+# lb soap
 
-Utilities to transform between SOAP WSDL and LoopBack remoting metadata.
+Utilities to transform between SOAP and LoopBack remoting metadata.
 
 This is an internal module used by the following user-facing tools:
 
- - ['lb soap' command in loopback-cli](https://github.com/strongloop/loopback-cli)
-
-
-## Installation
-
-To install the LoopBack CLI tool:
-
-```
-$ npm install -g loopback-cli
-```
-
-## Use
-
-
- 1. Run `lb` to create a new LoopBack application.
- 2. `cd` to newly created application directory.
- 3. Run `lb soap` When prompted, enter WSDL URL or local wsdl file path.
- 5. In the next prompts, select 'service', 'binding' and one or more WSDL operations to generate remote methods and models.
- 4. Run `node .` to start the server.
- 5. Browse your REST API at http://127.0.0.1/explorer and test the generated REST APIs.
-
+ - ['lb soap' command in loopback-cli](https://github.com/strongloop/loopback-cli) 
+ - Please refer ['lb soap' README in loopback-cli](https://github.com/strongloop/loopback-cli/blob/master/soap/README_Soap.md) for installation and usage.

--- a/soap/index.js
+++ b/soap/index.js
@@ -58,17 +58,17 @@ module.exports = yeoman.Base.extend({
 
   checkForDatasource: function() {
     var self = this;
+    self.soapDataSources = this.dataSources.filter(function(ds) {
+      return (ds._connector === 'soap') ||
+        (ds._connector === 'loopback-connector-soap');
+    });
+
     var soapDataSourceNames = [];
-    var soapDataSources = [];
-    for (var i in this.dataSources) {
-      var datasource = this.dataSources[i];
-      if (datasource._connector === 'soap') {
-        soapDataSourceNames.push(datasource.data.name);
-        soapDataSources.push(datasource);
-      }
-    }
+    self.soapDataSources.forEach(function(ds) {
+      soapDataSourceNames.push(ds.data.name);
+    });
+
     self.soapDataSourceNames = soapDataSourceNames;
-    self.soapDataSources = soapDataSources;
     if (this.soapDataSourceNames.length == 0) {
       var done = this.async();
       var error = chalk.red(g.f('Error: Found no SOAP WebServices' +
@@ -181,7 +181,8 @@ module.exports = yeoman.Base.extend({
 
     var api, i, n, m;
     self.operations = this.operations;
-    self.apis = generator.generateAPICode(this.selectedDS.data.name, this.operations); // eslint-disable-line max-len
+    self.apis = generator.generateAPICode(this.selectedDS.data.name,
+      this.operations);
 
     // eslint-disable-next-line one-var
     for (i = 0, n = self.apis.length; i < n; i++) {

--- a/soap/index.js
+++ b/soap/index.js
@@ -162,7 +162,7 @@ module.exports = yeoman.Base.extend({
         type: 'checkbox',
         choices: this.operations,
         default: this.operations,
-        validate: validateNoOperation
+        validate: validateNoOperation,
       },
     ];
 
@@ -371,7 +371,6 @@ module.exports = yeoman.Base.extend({
   saveProject: actions.saveProject,
 });
 function validateNoOperation(operations) {
-  console.log("operations %j" + operations);
   if (operations.length == 0) {
     return g.f('Please select at least one operation.');
   } else {

--- a/soap/wsdl-loader.js
+++ b/soap/wsdl-loader.js
@@ -74,9 +74,10 @@ function getSelectedOperations(binding, operationNames) {
 }
 
 // generate remote method and models for list of operations
-exports.generateAPICode  = function generateAPICode(operationNames) {
+exports.generateAPICode  = function generateAPICode(selectedDS, operationNames) { // eslint-disable-line max-len
   var apis = [];
   var apiData = {
+    'datasource': selectedDS,
     'wsdl': selectedWsdl,
     'wsdlUrl': selectedWsdlUrl,
     'service': selectedService.$name,

--- a/test/soap.test.js
+++ b/test/soap.test.js
@@ -12,109 +12,201 @@ var fs = require('fs');
 var expect = require('chai').expect;
 var common = require('./common');
 
-describe('loopback:soap', function() {
-  beforeEach(common.resetWorkspace);
-
-  beforeEach(function createSandbox(done) {
-    helpers.testDirectory(SANDBOX, done);
-  });
-
-  beforeEach(function createProject(done) {
-    common.createDummyProject(SANDBOX, 'test-soapapp', done);
-  });
-
-  it('stock quote wsdl',
-    function(done) {
-      var modelGen = givenModelGenerator();
+describe('loopback:soap tests', function() {
+  describe('stock quote wsdl', function() {
+    beforeEach(common.resetWorkspace);
+    beforeEach(function createSandbox(done) {
+      helpers.testDirectory(SANDBOX, done);
+    });
+    beforeEach(function createProject(done) {
+      common.createDummyProject(SANDBOX, 'test-soapapp', done);
+    });
+    beforeEach(function createDataSource(done) {
+      var modelGen = givenDataSourceGenerator();
       helpers.mockPrompt(modelGen, {
-        url: path.join(__dirname, 'soap/stockquote.wsdl'),
-        service: 'StockQuote',
-        binding: 'StockQuoteSoap',
-        operations: ['GetQuote'],
+        name: 'soapds',
+        customConnector: '', // temporary workaround for
+                             // https://github.com/yeoman/generator/issues/600
+        connector: 'soap',
+        url: 'http://www.webservicex.net/stockquote.asmx',
+        wsdl: path.join(__dirname, 'soap/stockquote.wsdl'),
+        remotingEnabled: true,
+        installConnector: false,
       });
-
-      // this runs command  loopback:soap command with mock up /test/soap/stockquote.wsdl as input from command prompt
       modelGen.run(function() {
-        var content = readModelJsonSync('get-quote');
-        expect(content).to.not.have.property('public');
-        expect(content).to.have.property('properties');
-        expect(content.properties.symbol.type).to.eql('string');
-        expect(content.properties.globals.type).to.eql('Globals');
-
-        content = readModelJsonSync('globals');
-        expect(content).to.not.have.property('public');
-        expect(content).to.have.property('properties');
-        expect(content.properties.Promise.type).to.eql('boolean');
-        expect(content.properties.Promise.type).to.eql('boolean');
-
-        content = readModelJsonSync('get-quote-response');
-        expect(content).to.not.have.property('public');
-        expect(content).to.have.property('properties');
-        expect(content.properties.GetQuoteResult.type).to.eql('string');
-
-        var modelConfig = readModelConfigSync('server');
-        expect(modelConfig).to.have.property('GetQuote');
-        expect(modelConfig.GetQuote).to.have.property('public', true);
         done();
       });
     });
 
-  it('periodic table wsdl',
-    function(done) {
-      var modelGen = givenModelGenerator();
-      helpers.mockPrompt(modelGen, {
-        url: 'http://www.webservicex.net/periodictable.asmx?WSDL',
-        service: 'periodictable',
-        binding: 'periodictableSoap',
-        operations: ['GetAtomicNumber', 'GetAtomicWeight'],
+    it('stock quote wsdl',
+      function(done) {
+        var modelGen = givenModelGenerator();
+        helpers.mockPrompt(modelGen, {
+          dataSource: 'soapds',
+          service: 'StockQuote',
+          binding: 'StockQuoteSoap',
+          operations: ['GetQuote'],
+        });
+
+        // this runs command  loopback:soap command with mock up /test/soap/stockquote.wsdl as input from command prompt
+        modelGen.run(function() {
+          var content = readModelJsonSync('get-quote');
+          expect(content).to.not.have.property('public');
+          expect(content).to.have.property('properties');
+          expect(content.properties.symbol.type).to.eql('string');
+          expect(content.properties.globals.type).to.eql('Globals');
+
+          content = readModelJsonSync('globals');
+          expect(content).to.not.have.property('public');
+          expect(content).to.have.property('properties');
+          expect(content.properties.Promise.type).to.eql('boolean');
+          expect(content.properties.Promise.type).to.eql('boolean');
+
+          content = readModelJsonSync('get-quote-response');
+          expect(content).to.not.have.property('public');
+          expect(content).to.have.property('properties');
+          expect(content.properties.GetQuoteResult.type).to.eql('string');
+
+          var modelConfig = readModelConfigSync('server');
+          expect(modelConfig).to.have.property('GetQuote');
+          expect(modelConfig.GetQuote).to.have.property('public', true);
+          done();
+        });
       });
-      // this runs command  loopback:soap command with mock up /test/soap/stockquote.wsdl as input from command prompt
+
+    function givenModelGenerator(modelArgs) {
+      var path = '../../soap';
+      var name = 'loopback:soap';
+      var deps = [];
+      var gen = common.createGenerator(name, path, deps, modelArgs, {});
+      return gen;
+    }
+
+    function readModelJsonSync(name) {
+      var soapJson = path.resolve(SANDBOX, 'server/models/' + name + '.json');
+      expect(fs.existsSync(soapJson), 'file exists');
+      return JSON.parse(fs.readFileSync(soapJson));
+    }
+
+    function givenDataSourceGenerator(dsArgs) {
+      var path = '../../datasource';
+      var name = 'loopback:datasource';
+      var gen = common.createGenerator(name, path, [], dsArgs, {});
+      return gen;
+    }
+
+    function readModelConfigSync(facet) {
+      facet = facet || 'server';
+      var filepath = path.resolve(SANDBOX, facet, 'model-config.json');
+      var content = fs.readFileSync(filepath, 'utf-8');
+      return JSON.parse(content);
+    }
+
+    function readDataSourcesJsonSync(facet) {
+      var filepath = path.resolve(SANDBOX, facet || 'server', 'datasources.json'); // eslint-disable-line max-len
+      var content = fs.readFileSync(filepath, 'utf-8');
+      return JSON.parse(content);
+    }
+  });
+  describe('periodic table wsdl', function() {
+    beforeEach(common.resetWorkspace);
+
+    beforeEach(function createSandbox(done) {
+      helpers.testDirectory(SANDBOX, done);
+    });
+
+    beforeEach(function createProject(done) {
+      common.createDummyProject(SANDBOX, 'test-soapapp', done);
+    });
+
+    beforeEach(function createDataSource(done) {
+      var modelGen = givenDataSourceGenerator();
+      helpers.mockPrompt(modelGen, {
+        name: 'soapds',
+        customConnector: '', // temporary workaround for
+                             // https://github.com/yeoman/generator/issues/600
+        connector: 'soap',
+        url: 'http://www.webservicex.net/periodictable.asmx',
+        wsdl: 'http://www.webservicex.net/periodictable.asmx?WSDL',
+        remotingEnabled: true,
+        installConnector: false,
+      });
       modelGen.run(function() {
-        var content = readModelJsonSync('get-atomic-weight');
-        expect(content).to.not.have.property('public');
-        expect(content).to.have.property('properties');
-        expect(content.properties.ElementName.type).to.eql('string');
-
-        content = readModelJsonSync('get-atomic-weight-response');
-        expect(content.properties.GetAtomicWeightResult.type).to.eql('string');
-
-        content = readModelJsonSync('get-atomic-number');
-        expect(content).to.not.have.property('public');
-        expect(content).to.have.property('properties');
-        expect(content.properties.ElementName.type).to.eql('string');
-
-        content = readModelJsonSync('get-atomic-number-response');
-        expect(content.properties.GetAtomicNumberResult.type).to.eql('string');
-
-        var modelConfig = readModelConfigSync('server');
-        expect(modelConfig).to.have.property('GetAtomicWeight');
-        expect(modelConfig.GetAtomicWeight).to.have.property('public', true);
-
-        expect(modelConfig).to.have.property('GetAtomicNumber');
-        expect(modelConfig.GetAtomicNumber).to.have.property('public', true);
-
         done();
       });
     });
 
-  function givenModelGenerator(modelArgs) {
-    var path = '../../soap';
-    var name = 'loopback:soap';
-    var deps = [];
-    var gen = common.createGenerator(name, path, deps, modelArgs, {});
-    return gen;
-  }
+    it('periodic table wsdl',
+      function(done) {
+        var modelGen = givenModelGenerator();
+        helpers.mockPrompt(modelGen, {
+          dataSource: 'soapds',
+          url: 'http://www.webservicex.net/periodictable.asmx?WSDL',
+          service: 'periodictable',
+          binding: 'periodictableSoap',
+          operations: ['GetAtomicNumber', 'GetAtomicWeight'],
+        });
+        // this runs command  loopback:soap command with mock up /test/soap/stockquote.wsdl as input from command prompt
+        modelGen.run(function() {
+          var content = readModelJsonSync('get-atomic-weight');
+          expect(content).to.not.have.property('public');
+          expect(content).to.have.property('properties');
+          expect(content.properties.ElementName.type).to.eql('string');
 
-  function readModelJsonSync(name) {
-    var soapJson = path.resolve(SANDBOX, 'server/models/' + name + '.json');
-    expect(fs.existsSync(soapJson), 'file exists');
-    return JSON.parse(fs.readFileSync(soapJson));
-  }
+          content = readModelJsonSync('get-atomic-weight-response');
+          expect(content.properties.GetAtomicWeightResult.type).to.eql('string'); // eslint-disable-line max-len
 
-  function readModelConfigSync(facet) {
-    facet = facet || 'server';
-    var filepath = path.resolve(SANDBOX, facet, 'model-config.json');
-    var content = fs.readFileSync(filepath, 'utf-8');
-    return JSON.parse(content);
-  }
+          content = readModelJsonSync('get-atomic-number');
+          expect(content).to.not.have.property('public');
+          expect(content).to.have.property('properties');
+          expect(content.properties.ElementName.type).to.eql('string');
+
+          content = readModelJsonSync('get-atomic-number-response');
+          expect(content.properties.GetAtomicNumberResult.type).to.eql('string'); // eslint-disable-line max-len
+
+          var modelConfig = readModelConfigSync('server');
+          expect(modelConfig).to.have.property('GetAtomicWeight');
+          expect(modelConfig.GetAtomicWeight).to.have.property('public', true);
+
+          expect(modelConfig).to.have.property('GetAtomicNumber');
+          expect(modelConfig.GetAtomicNumber).to.have.property('public', true);
+
+          done();
+        });
+      });
+
+    function givenModelGenerator(modelArgs) {
+      var path = '../../soap';
+      var name = 'loopback:soap';
+      var deps = [];
+      var gen = common.createGenerator(name, path, deps, modelArgs, {});
+      return gen;
+    }
+
+    function readModelJsonSync(name) {
+      var soapJson = path.resolve(SANDBOX, 'server/models/' + name + '.json');
+      expect(fs.existsSync(soapJson), 'file exists');
+      return JSON.parse(fs.readFileSync(soapJson));
+    }
+
+    function givenDataSourceGenerator(dsArgs) {
+      var path = '../../datasource';
+      var name = 'loopback:datasource';
+      var gen = common.createGenerator(name, path, [], dsArgs, {});
+      return gen;
+    }
+
+    function readModelConfigSync(facet) {
+      facet = facet || 'server';
+      var filepath = path.resolve(SANDBOX, facet, 'model-config.json');
+      var content = fs.readFileSync(filepath, 'utf-8');
+      return JSON.parse(content);
+    }
+
+    function readDataSourcesJsonSync(facet) {
+      var filepath = path.resolve(SANDBOX, facet || 'server', 'datasources.json'); // eslint-disable-line max-len
+      var content = fs.readFileSync(filepath, 'utf-8');
+      return JSON.parse(content);
+    }
+  });
 });


### PR DESCRIPTION
This PR has 
1)  support for  “lb soap” integration with SOAP WebServices datasource
2) support for updates if models already exist
3) Fixed Issue https://github.com/strongloop/loopback-cli/issues/28
4) Updated existing tests 
5) Updated README to point to loopback-cli README as single source of information. 
6) README in loopback-cli to change from WSDL URL - > datasource name will be done through another PR in loopback-cli repo
@raymondfeng PTAL
