### PR TITLE
Add excludeBaseProperties support

### DIFF
--- a/soap/index.js
+++ b/soap/index.js
@@ -199,8 +199,9 @@ module.exports = yeoman.Base.extend({
           path: basePath,
         },
         base: 'Model',
-        forceId: 'false', // in case of soap, we don't need id generated in the model
+        forceId: 'false',
         idInjection: 'false',
+        excludeBaseProperties: 'id', // for soap model, we need to exclude if generated in base 'Model'
         facetName: 'server', // hard-coded for now
         properties: {},
       };
@@ -227,9 +228,10 @@ module.exports = yeoman.Base.extend({
           name: model.name,
           plural: model.plural,
           base: model.base || 'Model',
-          forceId: 'false', // in case of soap, we don't need id generated in the model
+          forceId: 'false',
           idInjection: 'false',
-          facetName: 'server', // hard-coded for now
+          excludeBaseProperties: 'id', // for soap model, we need to exclude if generated in base 'Model'
+          facetName: 'common', // hard-coded for now
           properties: model.properties,
         });
         self.modelConfigs.push({

--- a/soap/index.js
+++ b/soap/index.js
@@ -201,7 +201,7 @@ module.exports = yeoman.Base.extend({
         base: 'Model',
         forceId: 'false',
         idInjection: 'false',
-        excludeBaseProperties: 'id', // for soap model, we need to exclude if generated in base 'Model'
+        excludeBaseProperties: ['id'], // for soap model, we need to exclude if generated in base 'Model'
         facetName: 'server', // hard-coded for now
         properties: {},
       };
@@ -230,7 +230,7 @@ module.exports = yeoman.Base.extend({
           base: model.base || 'Model',
           forceId: 'false',
           idInjection: 'false',
-          excludeBaseProperties: 'id', // for soap model, we need to exclude if generated in base 'Model'
+          excludeBaseProperties: ['id'], // for soap model, we need to exclude if generated in base 'Model'
           facetName: 'common', // hard-coded for now
           properties: model.properties,
         });

--- a/test/soap.test.js
+++ b/test/soap.test.js
@@ -152,7 +152,10 @@ describe('loopback:soap tests', function() {
           expect(content).to.not.have.property('public');
           expect(content).to.have.property('properties');
           expect(content.properties.ElementName.type).to.eql('string');
-          expect(content).to.have.property('excludeBaseProperties', 'id');
+          expect(content).to.have.property('excludeBaseProperties');
+          var expectedExcludeProps = ['id'];
+          expect(content.excludeBaseProperties).
+                      to.deep.equal(expectedExcludeProps);
 
           content = readModelJsonSync('get-atomic-weight-response');
           expect(content.properties.GetAtomicWeightResult.type).to.eql('string'); // eslint-disable-line max-len

--- a/test/soap.test.js
+++ b/test/soap.test.js
@@ -83,7 +83,7 @@ describe('loopback:soap tests', function() {
     }
 
     function readModelJsonSync(name) {
-      var soapJson = path.resolve(SANDBOX, 'server/models/' + name + '.json');
+      var soapJson = path.resolve(SANDBOX, 'common/models/' + name + '.json');
       expect(fs.existsSync(soapJson), 'file exists');
       return JSON.parse(fs.readFileSync(soapJson));
     }
@@ -152,6 +152,7 @@ describe('loopback:soap tests', function() {
           expect(content).to.not.have.property('public');
           expect(content).to.have.property('properties');
           expect(content.properties.ElementName.type).to.eql('string');
+          expect(content).to.have.property('excludeBaseProperties', 'id');
 
           content = readModelJsonSync('get-atomic-weight-response');
           expect(content.properties.GetAtomicWeightResult.type).to.eql('string'); // eslint-disable-line max-len
@@ -184,7 +185,7 @@ describe('loopback:soap tests', function() {
     }
 
     function readModelJsonSync(name) {
-      var soapJson = path.resolve(SANDBOX, 'server/models/' + name + '.json');
+      var soapJson = path.resolve(SANDBOX, 'common/models/' + name + '.json');
       expect(fs.existsSync(soapJson), 'file exists');
       return JSON.parse(fs.readFileSync(soapJson));
     }


### PR DESCRIPTION
@raymondfeng PTAL This PR:
- handles excludeBaseProperties from base 'Model' - This is for fixing strongloop/loopback-workspace#486 
- Also generates SOAP models under 'common' instead of 'server'
- Test case changes