### PR TITLE
Add --login=false to avoid BM login for tests

### DIFF
--- a/bluemix/login.js
+++ b/bluemix/login.js
@@ -18,9 +18,10 @@ function login() {
   if (config) {
     this.accessToken = config.accessToken;
   }
+  // Skip login if --login=false
+  if (this.options.login === false) return;
   // Skip login if --login or --sso is not present and accessToken is found
-  if (!(this.options.login || this.options.sso) && this.accessToken)
-    return;
+  if (!(this.options.login || this.options.sso) && this.accessToken) return;
   var done = this.async();
   this.log(g.f('Log into your Bluemix account:'));
   var prompts = [

--- a/package.json
+++ b/package.json
@@ -45,20 +45,17 @@
     "strong-soap": "^1.2.2",
     "text-table": "^0.2.0",
     "yaml-js": "^0.1.4",
-    "yeoman-generator": "^0.23.1",
-    "yosay": "^1.0.5"
+    "yeoman-generator": "^0.23.1"
   },
   "devDependencies": {
     "bluebird": "^3.1.1",
     "chai": "^3.2.0",
     "eslint": "^3.11.1",
     "eslint-config-loopback": "^8.0.0",
-    "fs-extra": "^2.1.2",
     "mocha": "^3.2.0",
     "rimraf": "^2.6.1",
     "semver": "^5.1.0",
     "strong-cached-install": "^2.0.0",
-    "yaml-js": "^0.1.4",
     "yeoman-assert": "^2.2.1",
     "yeoman-test": "^1.4.0"
   }

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -208,6 +208,7 @@ describe('loopback:app generator', function() {
 
       gen.options['skip-install'] = true;
       gen.options['bluemix'] = true;
+      gen.options['login'] = false;
 
       gen.run(function() {
         ygAssert.file(EXPECTED_PROJECT_FILES.concat(EXPECTED_BLUEMIX_FILES));
@@ -235,6 +236,7 @@ describe('loopback:app generator', function() {
 
       gen.options['skip-install'] = true;
       gen.options['bluemix'] = true;
+      gen.options['login'] = false;
 
       gen.run(function() {
         ygAssert.noFile(DOCKER_FILES);
@@ -261,6 +263,7 @@ describe('loopback:app generator', function() {
 
       gen.options['skip-install'] = true;
       gen.options['bluemix'] = true;
+      gen.options['login'] = false;
 
       gen.run(function() {
         ygAssert.file('.bluemix/datasources-config.json');

--- a/test/bluemix.test.js
+++ b/test/bluemix.test.js
@@ -34,6 +34,10 @@ var TOOLCHAIN_FILES = [
   '.bluemix/toolchain.yml',
 ];
 
+function itSkipIf(flag) {
+  return flag ? it.skip : it;
+}
+
 describe('loopback:bluemix generator', function() {
   beforeEach(common.resetWorkspace);
 
@@ -139,12 +143,8 @@ describe('loopback:bluemix generator', function() {
     });
   });
 
-  it('should login with user/password', function(done) {
-    if (!process.env.BLUEMIX_EMAIL || !process.env.BLUEMIX_PASSWORD) {
-      var msg = '    x Missing BLUEMIX_EMAIL and BLUEMIX_PASSWORD env vars';
-      console.error(msg);
-      return this.skip(); // Skip the test
-    }
+  itSkipIf(!process.env.BLUEMIX_EMAIL || !process.env.BLUEMIX_PASSWORD)(
+  'should login with user/password', function(done) {
     var gen = givenBluemixGenerator('--force --login');
     helpers.mockPrompt(gen, {
       email: process.env.BLUEMIX_EMAIL,
@@ -159,12 +159,8 @@ describe('loopback:bluemix generator', function() {
     });
   });
 
-  it('should login with SSO passcode', function(done) {
-    if (!process.env.BLUEMIX_PASSCODE) {
-      var msg = '    x Missing BLUEMIX_PASSCODE env var';
-      console.error(msg);
-      return this.skip();
-    }
+  itSkipIf(!process.env.BLUEMIX_EMAIL || !process.env.BLUEMIX_PASSWORD)(
+  'should login with SSO passcode', function(done) {
     var gen = givenBluemixGenerator('--force --sso');
     helpers.mockPrompt(gen, {
       password: process.env.BLUEMIX_PASSCODE,

--- a/test/model.test.js
+++ b/test/model.test.js
@@ -202,7 +202,7 @@ describe('loopback:model generator', function() {
                       'datasources-config.json');
         fs.copySync(srcPath, destPath);
 
-        var modelGen = givenModelGenerator('--bluemix');
+        var modelGen = givenModelGenerator('--bluemix --login=false');
         helpers.mockPrompt(modelGen, {
           name: 'Product',
         });
@@ -220,7 +220,7 @@ describe('loopback:model generator', function() {
                       'datasources-config.json');
         fs.copySync(srcPath, destPath);
 
-        var modelGen = givenModelGenerator('--bluemix');
+        var modelGen = givenModelGenerator('--bluemix --login=false');
         helpers.mockPrompt(modelGen, {
           name: 'Product',
           dataSource: 'cloudant-demo-service',


### PR DESCRIPTION
### Description

When cached BM config is not found, the tests fail due to login requests without this change.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
