### PR TITLE
Separate command for service provisioning

### DIFF
--- a/bluemix/helpers.js
+++ b/bluemix/helpers.js
@@ -12,16 +12,43 @@ var yaml = require('yaml-js');
 var helpers = require('../lib/helpers');
 var helpText = require('../lib/help');
 var lbBm = require('loopback-bluemix');
+var provision = require('loopback-bluemix').provision;
 
 var bluemix = exports;
 
 // All actions defined in this file should be called with `this` pointing
 // to a generator instance
 
+bluemix.promptServiceName = function() {
+  if (!this.done && this.options.provision) {
+    provision.promptServiceName(this, g);
+  }
+};
+
+bluemix.getServicePlans = function() {
+  if (!this.done && this.options.provision) {
+    provision.getServicePlans(this);
+  }
+};
+
+bluemix.promptServicePlan = function() {
+  if (!this.done && this.options.provision) {
+    provision.promptServicePlan(this, g);
+  }
+};
+
+bluemix.provisionService = function() {
+  if (!this.done && this.options.provision) {
+    provision.provisionService(this, g);
+    this.done = true;
+  }
+};
+
 /**
  * Prepare prompts for bluemix options
  */
 bluemix.configurePrompt = function() {
+  if (this.done) return;
   // https://github.com/strongloop/generator-loopback/issues/38
   // yeoman-generator normalize the appname with ' '
   this.appName = path.basename(process.cwd())
@@ -145,6 +172,7 @@ bluemix.configurePrompt = function() {
 };
 
 bluemix.generateFiles = function() {
+  if (this.done) return;
   if (this.bluemix) {
     var bluemixOptions = {
       destDir: this.destinationRoot(),
@@ -159,6 +187,7 @@ bluemix.generateFiles = function() {
 };
 
 bluemix.promptDefaultServices = function() {
+  if (this.done) return;
   if (this.enableDefaultServices) {
     var prompts = [
       {
@@ -182,6 +211,7 @@ bluemix.promptDefaultServices = function() {
 };
 
 bluemix.addDefaultServices = function() {
+  if (this.done) return;
   if (this.enableDefaultServices) {
     var done = this.async();
     var options = {

--- a/bluemix/index.js
+++ b/bluemix/index.js
@@ -22,7 +22,7 @@ var pkg = require('../package.json');
 module.exports = yeoman.Base.extend({
   constructor: function() {
     yeoman.Base.apply(this, arguments);
-
+    this.done = false;
     this.option('docker', {
       desc: g.f('Generate Dockerfile'),
       type: Boolean,
@@ -48,6 +48,12 @@ module.exports = yeoman.Base.extend({
       desc: g.f('Log into Bluemix with SSO'),
       type: Boolean,
     });
+
+    this.option('provision', {
+      desc: g.f('Provision a Bluemix service'),
+      type: Boolean,
+      default: false,
+    });
   },
 
   help: function() {
@@ -68,6 +74,11 @@ module.exports = yeoman.Base.extend({
   loginToBluemix: function() {
     bluemix.login.apply(this);
   },
+
+  promptServiceName: bluemix.promptServiceName,
+  getServicePlans: bluemix.getServicePlans,
+  promptServicePlan: bluemix.promptServicePlan,
+  provisionService: bluemix.provisionService,
 
   configurePrompt: bluemix.configurePrompt,
   promptBluemixSettings: bluemix.promptSettings,

--- a/datasource/index.js
+++ b/datasource/index.js
@@ -151,24 +151,8 @@ module.exports = yeoman.Base.extend({
     if (this.options.bluemix) { ds.selectBluemixDatasource(this, g); }
   },
 
-  promptServiceName: function() {
-    if (this.provisionNewService) { ds.promptServiceName(this, g); }
-  },
-
-  getServicePlans: function() {
-    if (this.provisionNewService) { ds.getServicePlans(this); }
-  },
-
-  promptServicePlan: function() {
-    if (this.provisionNewService) { ds.promptServicePlan(this, g); }
-  },
-
-  provisionService: function() {
-    if (this.provisionNewService) { ds.provisionService(this, g); }
-  },
-
   bindServiceToApp: function() {
-    if (this.provisionNewService || this.options.bluemix) {
+    if (this.options.bluemix) {
       ds.bindServiceToApp(this);
     }
   },

--- a/intl/en/loopback_bluemix_usage.txt
+++ b/intl/en/loopback_bluemix_usage.txt
@@ -1,3 +1,5 @@
 Description:
   `toolchain`, `manifest`, and `docker` are scaffold options. Not specifying any of them is interpreted as
   specifying all of them.
+
+  Specify `provision` to provision a LoopBack-supported Bluemix data service.

--- a/test/fixtures/help-texts/loopback_bluemix_help.txt
+++ b/test/fixtures/help-texts/loopback_bluemix_help.txt
@@ -10,7 +10,10 @@ Options:
         --toolchain     # Set up Bluemix toolchain
         --login         # Log into Bluemix                           Default: false
         --sso           # Log into Bluemix with SSO
+        --provision     # Provision a Bluemix service                Default: false
 
 Description:
   `toolchain`, `manifest`, and `docker` are scaffold options. Not specifying any of them is interpreted as
   specifying all of them.
+
+  Specify `provision` to provision a LoopBack-supported Bluemix data service.


### PR DESCRIPTION
### Description

Separate command for service provisioning

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
