### PR TITLE
Add z/OS Connect EE command

### DIFF
--- a/intl/en/loopback_zosconnectee_usage.txt
+++ b/intl/en/loopback_zosconnectee_usage.txt
@@ -1,0 +1,6 @@
+Description:
+  Configures a z/OS Connect EE DataSource.
+
+Example:
+
+  {{slc loopback:zosconnectee}}

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "inflection": "^1.7.1",
     "js-yaml": "^3.4.2",
     "jsonfile-updater": "^2.1.0",
+    "json-schema-faker": "^0.4.0",
     "lodash": "^4.16.1",
     "loopback-api-definition": "^3.0.0",
     "loopback-bluemix": "^3.0.0",
@@ -47,7 +48,8 @@
     "swagger-parser": "^4.0.1",
     "text-table": "^0.2.0",
     "yaml-js": "^0.1.4",
-    "yeoman-generator": "^0.24.1"
+    "yeoman-generator": "^0.24.1",
+    "zosconnect-node": "^1.0.3"
   },
   "devDependencies": {
     "bluebird": "^3.1.1",
@@ -55,6 +57,7 @@
     "eslint": "^3.11.1",
     "eslint-config-loopback": "^8.0.0",
     "mocha": "^3.2.0",
+    "nock": "^9.0.14",
     "rimraf": "^2.6.1",
     "semver": "^5.1.0",
     "sinon": "^3.2.1",

--- a/test/zosconnectee.test.js
+++ b/test/zosconnectee.test.js
@@ -1,0 +1,115 @@
+// Copyright IBM Corp. 2017. All Rights Reserved.
+// Node module: generator-loopback
+// This file is licensed under the MIT License.
+// License text available at https://opensource.org/licenses/MIT
+
+/* global describe, beforeEach, it */
+'use strict';
+var path = require('path');
+var helpers = require('yeoman-test');
+var SANDBOX = path.resolve(__dirname, 'sandbox');
+var fs = require('fs');
+var expect = require('chai').expect;
+var common = require('./common');
+var nock = require('nock');
+
+var apiSwagger = require('./zosconnectee/swagger.json');
+
+describe('loopback:zosconnectee generator', function() {
+  beforeEach(common.resetWorkspace);
+
+  beforeEach(function createSandbox(done) {
+    helpers.testDirectory(SANDBOX, done);
+  });
+
+  beforeEach(function createProject(done) {
+    common.createDummyProject(SANDBOX, 'test-app', done);
+  });
+
+  beforeEach(function createDataSource(done) {
+    var modelGen = givenDataSourceGenerator();
+    helpers.mockPrompt(modelGen, {
+      name: 'zosconnectee',
+      connector: 'zosconnectee',
+      baseURL: 'http://test:9080',
+      user: 'user',
+      password: 'pass',
+      installConnector: false,
+    });
+    modelGen.run(function() {
+      done();
+    });
+  });
+
+  it('creates and configures CatalogManager API',
+    function(done) {
+      // Setup the http requests
+      nock('http://test:9080').get('/zosConnect/apis').reply(200, {
+        apis: [
+          {
+            adminUrl: 'http://test:9080/zosConnect/apis/catalog',
+            description: '',
+            name: 'catalog',
+            version: '1.0.0',
+          },
+        ],
+      });
+      nock('http://test:9080').get('/zosConnect/apis/catalog').reply(200, {
+        apiUrl: 'http://test:9080/catalog',
+        description: '',
+        documentation: {
+          swagger: 'http://test:9080/catalog/api-docs',
+        },
+        name: 'catalog',
+        status: 'started',
+        version: '1.0.0',
+      });
+      nock('http://test:9080').get('/catalog/api-docs').reply(200, apiSwagger);
+
+      var modelGen = givenModelGenerator();
+      helpers.mockPrompt(modelGen, {
+        ds: 'zosconnectee',
+        api: 'catalog',
+      });
+
+      modelGen.run(function() {
+        var template = readTemplateJsonSync('zosconnectee_template.json');
+        expect(template).to.have.property('name', 'catalog');
+        expect(template).to.have.property('connector', 'zosconnectee');
+        expect(template).to.have.property('baseURL', 'http://test:9080/catalog');
+        expect(template).to.have.property('operations').with.lengthOf(3);
+        var datasources = readDataSourcesJsonSync('server');
+        expect(datasources).to.have.property('zosconnectee');
+        expect(datasources.zosconnectee).to.have.property('template',
+          'zosconnectee_template.json');
+        done();
+      });
+    }
+  );
+
+  function givenDataSourceGenerator(dsArgs, _dsPath) {
+    var dsPath = _dsPath || '../../datasource';
+    var name = 'loopback:datasource';
+    var gen = common.createGenerator(name, dsPath, [], dsArgs, {});
+    return gen;
+  }
+
+  function givenModelGenerator(modelArgs) {
+    var path = '../../zosconnectee';
+    var name = 'loopback:zosconnectee';
+    var deps = [];
+    var gen = common.createGenerator(name, path, deps, modelArgs, {});
+    return gen;
+  }
+
+  function readDataSourcesJsonSync(facet) {
+    var filepath = path.resolve(SANDBOX, facet || 'server', 'datasources.json');
+    var content = fs.readFileSync(filepath, 'utf-8');
+    return JSON.parse(content);
+  }
+
+  function readTemplateJsonSync(template) {
+    var content = fs.readFileSync(SANDBOX + '/server/' + template, 'utf-8');
+    return JSON.parse(content);
+  }
+});

--- a/test/zosconnectee/swagger.json
+++ b/test/zosconnectee/swagger.json
@@ -1,0 +1,285 @@
+{
+  "swagger" : "2.0",
+  "info" : {
+    "description" : "API for the CICS catalog manager sample application",
+    "version" : "1.0.0",
+    "title" : "catalog"
+  },
+  "host" : "",
+  "basePath" : "/catalogManager",
+  "schemes" : [ "https", "http" ],
+  "consumes" : [ "application/json" ],
+  "produces" : [ "application/json" ],
+  "paths" : {
+    "/items" : {
+      "get" : {
+        "operationId" : "getInquireCatalog",
+        "parameters" : [ {
+          "name" : "Authorization",
+          "in" : "header",
+          "required" : false,
+          "type" : "string"
+        }, {
+          "name" : "startItemID",
+          "in" : "query",
+          "required" : true,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "normal response",
+            "schema" : {
+              "$ref" : "#/definitions/getInquireCatalog_response_200"
+            }
+          }
+        }
+      }
+    },
+    "/items/{itemID}" : {
+      "get" : {
+        "operationId" : "getInquireSingle",
+        "parameters" : [ {
+          "name" : "itemID",
+          "in" : "path",
+          "required" : true,
+          "type" : "string"
+        }, {
+          "name" : "Authorization",
+          "in" : "header",
+          "required" : false,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "normal response",
+            "schema" : {
+              "$ref" : "#/definitions/getInquireSingle_response_200"
+            }
+          }
+        }
+      }
+    },
+    "/orders" : {
+      "post" : {
+        "operationId" : "postPlaceOrder",
+        "parameters" : [ {
+          "in" : "body",
+          "name" : "postPlaceOrder_request",
+          "description" : "request body",
+          "required" : true,
+          "schema" : {
+            "$ref" : "#/definitions/postPlaceOrder_request"
+          }
+        }, {
+          "name" : "Authorization",
+          "in" : "header",
+          "required" : false,
+          "type" : "string"
+        } ],
+        "responses" : {
+          "200" : {
+            "description" : "normal response",
+            "schema" : {
+              "$ref" : "#/definitions/postPlaceOrder_response_200"
+            }
+          }
+        }
+      }
+    }
+  },
+  "definitions" : {
+    "postPlaceOrder_request" : {
+      "type" : "object",
+      "required" : [ "DFH0XCMNOperation" ],
+      "properties" : {
+        "DFH0XCMNOperation" : {
+          "type" : "object",
+          "properties" : {
+            "ca_order_request" : {
+              "type" : "object",
+              "properties" : {
+                "ca_item_ref_number" : {
+                  "type" : "integer",
+                  "minimum" : 0.0,
+                  "maximum" : 9999.0
+                },
+                "ca_quantity_req" : {
+                  "type" : "integer",
+                  "minimum" : 0.0,
+                  "maximum" : 999.0
+                }
+              },
+              "required" : [ "ca_item_ref_number", "ca_quantity_req" ]
+            }
+          },
+          "required" : [ "ca_order_request" ]
+        }
+      },
+      "description" : "Request schema for the DFH0XCMN JSON interface"
+    },
+    "getInquireCatalog_response_200" : {
+      "type" : "object",
+      "required" : [ "DFH0XCMNOperationResponse" ],
+      "properties" : {
+        "DFH0XCMNOperationResponse" : {
+          "type" : "object",
+          "properties" : {
+            "ca_return_code" : {
+              "type" : "integer",
+              "minimum" : 0.0,
+              "maximum" : 99.0
+            },
+            "ca_inquire_request" : {
+              "type" : "object",
+              "properties" : {
+                "ca_last_item_ref" : {
+                  "type" : "integer",
+                  "minimum" : 0.0,
+                  "maximum" : 9999.0
+                },
+                "ca_item_count" : {
+                  "type" : "integer",
+                  "minimum" : 0.0,
+                  "maximum" : 999.0
+                },
+                "ca_cat_item" : {
+                  "type" : "array",
+                  "items" : {
+                    "type" : "object",
+                    "properties" : {
+                      "ca_cost" : {
+                        "type" : "string",
+                        "maxLength" : 6
+                      },
+                      "in_stock" : {
+                        "type" : "integer",
+                        "minimum" : 0.0,
+                        "maximum" : 9999.0
+                      },
+                      "ca_description" : {
+                        "type" : "string",
+                        "maxLength" : 40
+                      },
+                      "on_order" : {
+                        "type" : "integer",
+                        "minimum" : 0.0,
+                        "maximum" : 999.0
+                      },
+                      "ca_department" : {
+                        "type" : "integer",
+                        "minimum" : 0.0,
+                        "maximum" : 999.0
+                      },
+                      "ca_item_ref" : {
+                        "type" : "integer",
+                        "minimum" : 0.0,
+                        "maximum" : 9999.0
+                      }
+                    },
+                    "required" : [ "ca_cost", "ca_department", "ca_description", "ca_item_ref", "in_stock", "on_order" ]
+                  }
+                },
+                "ca_list_start_ref" : {
+                  "type" : "integer",
+                  "minimum" : 0.0,
+                  "maximum" : 9999.0
+                }
+              },
+              "required" : [ "ca_cat_item", "ca_item_count", "ca_last_item_ref", "ca_list_start_ref" ]
+            },
+            "ca_response_message" : {
+              "type" : "string",
+              "maxLength" : 79
+            }
+          },
+          "required" : [ "ca_inquire_request", "ca_response_message", "ca_return_code" ]
+        }
+      },
+      "description" : "Response schema for the DFH0XCMN JSON interface"
+    },
+    "postPlaceOrder_response_200" : {
+      "type" : "object",
+      "required" : [ "DFH0XCMNOperationResponse" ],
+      "properties" : {
+        "DFH0XCMNOperationResponse" : {
+          "type" : "object",
+          "properties" : {
+            "ca_return_code" : {
+              "type" : "integer",
+              "minimum" : 0.0,
+              "maximum" : 99.0
+            },
+            "ca_response_message" : {
+              "type" : "string",
+              "maxLength" : 79
+            }
+          },
+          "required" : [ "ca_response_message", "ca_return_code" ]
+        }
+      },
+      "description" : "Response schema for the DFH0XCMN JSON interface"
+    },
+    "getInquireSingle_response_200" : {
+      "type" : "object",
+      "required" : [ "DFH0XCMNOperationResponse" ],
+      "properties" : {
+        "DFH0XCMNOperationResponse" : {
+          "type" : "object",
+          "properties" : {
+            "ca_return_code" : {
+              "type" : "integer",
+              "minimum" : 0.0,
+              "maximum" : 99.0
+            },
+            "ca_response_message" : {
+              "type" : "string",
+              "maxLength" : 79
+            },
+            "ca_inquire_single" : {
+              "type" : "object",
+              "properties" : {
+                "ca_single_item" : {
+                  "type" : "object",
+                  "properties" : {
+                    "in_sngl_stock" : {
+                      "type" : "integer",
+                      "minimum" : 0.0,
+                      "maximum" : 9999.0
+                    },
+                    "ca_sngl_description" : {
+                      "type" : "string",
+                      "maxLength" : 40
+                    },
+                    "ca_sngl_item_ref" : {
+                      "type" : "integer",
+                      "minimum" : 0.0,
+                      "maximum" : 9999.0
+                    },
+                    "on_sngl_order" : {
+                      "type" : "integer",
+                      "minimum" : 0.0,
+                      "maximum" : 999.0
+                    },
+                    "ca_sngl_cost" : {
+                      "type" : "string",
+                      "maxLength" : 6
+                    },
+                    "ca_sngl_department" : {
+                      "type" : "integer",
+                      "minimum" : 0.0,
+                      "maximum" : 999.0
+                    }
+                  },
+                  "required" : [ "ca_sngl_cost", "ca_sngl_department", "ca_sngl_description", "ca_sngl_item_ref", "in_sngl_stock", "on_sngl_order" ]
+                }
+              },
+              "required" : [ "ca_single_item" ]
+            }
+          },
+          "required" : [ "ca_inquire_single", "ca_response_message", "ca_return_code" ]
+        }
+      },
+      "description" : "Response schema for the DFH0XCMN JSON interface"
+    }
+  }
+}

--- a/zosconnectee/README.md
+++ b/zosconnectee/README.md
@@ -1,0 +1,10 @@
+# lb zosconnectee
+
+Utility to configure [loopback-connector-zosconnectee](https://github.com/strongloop/loopback-connector-zosconnectee) data sources.
+
+## Usage
+
+Run the `lb zosconnectee` at the root directory of your LoopBack application.
+
+The command attempts to connect to the z/OS Connect Enterprise Edition server, retrieve the list of available APIs and then configure
+the datasource based on the Swagger document for the selected API.

--- a/zosconnectee/index.js
+++ b/zosconnectee/index.js
@@ -1,0 +1,192 @@
+'use strict';
+
+var generators = require('yeoman-generator');
+var ZosConnect = require('zosconnect-node');
+var fs = require('fs');
+var jsf = require('json-schema-faker');
+var chalk = require('chalk');
+var wsModels = require('loopback-workspace').models;
+
+var helpText = require('../lib/help');
+
+module.exports = generators.Base.extend({
+  constructor: function() {
+    generators.Base.apply(this, arguments);
+    this.updateObj = function(obj, parameters) {
+      for (var key in obj) {
+        if (typeof obj[key] === 'object') {
+          this.updateObj(obj[key], parameters);
+        } else {
+          obj[key] = '{' + key + '}';
+          parameters.push(key);
+        }
+      }
+      return obj;
+    };
+  },
+  help: function() {
+    return helpText.customHelp(this, 'loopback_zosconnectee_usage.txt');
+  },
+  initializing: function() {
+    var done = this.async();
+    var that = this; // that will be used as a reference to this in all the async jobs
+
+    wsModels.DataSourceDefinition.find(
+      function(err, dsDef) {
+        var tempList = [];
+        dsDef.map(function(datasource) {
+          if (datasource.connector == 'zosconnectee') {
+            tempList.push(datasource);
+          }
+        });
+        that.datasources = tempList;
+        if (that.datasources.length == 0) {
+          that.env.error(
+            'Define a zosconnectee datasource before running this command');
+        }
+        done(); // End the sync
+      }
+    );
+  },
+  prompting: {
+    getDataSources: function() {
+      return this.prompt([{
+        type: 'list',
+        name: 'ds',
+        message: 'Which data source you want to Discover APIs for?',
+        choices: this.datasources,
+        validate: function(input) {
+          var done = this.async();
+          if (input == '') {
+            done('You should provide at least one data source');
+          }
+          done(null, true);
+        },
+      }]).then(function(answers) {
+        var tempSource;
+        this.datasources.map(function(datasource) {
+          if (answers.ds.indexOf(datasource.name) >= 0) {
+            tempSource = datasource;
+          }
+        });
+        this.dataSource = tempSource;
+      }.bind(this));
+    },
+    getapis: function() {
+      var that = this;
+      var done = this.async();
+      var options = {
+        uri: this.dataSource.baseURL,
+        strictSSL: false,
+      };
+      if (this.dataSource.user !== '') {
+        options.auth = {
+          user: this.dataSource.user,
+          pass: this.dataSource.password,
+        };
+      }
+      this.zosconnect = new ZosConnect(options);
+      this.zosconnect.getApis()
+        .then(function(apis) { that.apiList = apis; done(null, true); })
+        .catch(done);
+    },
+    selectApi: function() {
+      return this.prompt([{
+        type: 'list',
+        name: 'api',
+        message: 'Choose API',
+        choices: this.apiList,
+      }]).then(function(answers) {
+        this.apiName = answers.api;
+      }.bind(this));
+    },
+    loadApi: function() {
+      var done = this.async();
+      var that = this;
+      this.zosconnect.getApi(this.apiName)
+        .then(function(api) { that.api = api; done(null, true); })
+        .catch(done);
+    },
+    loadSwagger: function() {
+      var done = this.async();
+      var that = this;
+      this.api.getApiDoc('swagger')
+        .then(function(swagger) {
+          that.swagger = JSON.parse(swagger);
+          done(null, true);
+        })
+        .catch(done);
+    },
+  },
+  writing: {
+    generateTemplate: function() {
+      this.masterTemplate = {};
+      var masterTemplate = this.masterTemplate;
+      masterTemplate.name = this.swagger.info.title;
+      masterTemplate.baseURL = this.api.basePath;
+      masterTemplate.crud = false;
+      masterTemplate.connector = 'zosconnectee';
+      if (this.dataSource.user !== '') {
+        masterTemplate.options = {
+          auth: {
+            user: this.dataSource.user,
+            pass: this.dataSource.password,
+          },
+        };
+      }
+      var operations = [];
+      for (var path in this.swagger.paths) {
+        for (var method in this.swagger.paths[path]) {
+          var functions = {};
+          var template = {};
+          var that = this;
+          template.method = method;
+          template.url = this.api.basePath + path;
+          template.headers = {
+            'accepts': 'application/json',
+            'content-type': 'application/json',
+          };
+          var operation = this.swagger.paths[path][method];
+          var parameters = [];
+          operation.parameters.map(function(parameter) {
+            if (parameter.required) {
+              if (parameter['in'] == 'query') {
+                if (template.query === undefined) {
+                  template.query = {};
+                }
+                template.query[parameter.name] = '{' + parameter.name + '}';
+                parameters.push(parameter.name);
+              } else if (parameter['in'] == 'path') {
+                parameters.push(parameter.name);
+              } else if (parameter['in'] == 'body') {
+                var schemaRef = parameter.schema.$ref;
+                template.body = that.updateObj(jsf(that.swagger.definitions[schemaRef.substring(schemaRef.lastIndexOf('/') + 1)]), parameters);
+              }
+            }
+          });
+          functions[operation.operationId] = parameters;
+          template.responsePath = '$';
+          operations.push({
+            'functions': functions,
+            'template': template,
+          });
+        }
+      }
+      masterTemplate.operations = operations;
+    },
+    writeDataSource: function() {
+      var dataSources = JSON.parse(fs.readFileSync('server/datasources.json'));
+      var templateFile = 'server/' + this.dataSource.name + '_template.json';
+      fs.writeFileSync(templateFile,
+                JSON.stringify(this.masterTemplate, null, 2));
+      dataSources[this.dataSource.name].template =
+                this.dataSource.name + '_template.json';
+      fs.writeFileSync('server/datasources.json',
+                JSON.stringify(dataSources, null, 2));
+    },
+  },
+  end: function() {
+    this.log('Configured DataSource', chalk.bold(this.dataSource.name),
+            'for API', chalk.bold(this.apiName));
+  },
+});


### PR DESCRIPTION
### Description
Add a new command, `zosconnectee` to the `lb` command which:
1. Connects to the z/OS Connect EE server for a specified datasource
2. Retrieves the list of available APIs
3. Retrieves the Swagger document for the selected API and configures the Datasource

#### Related issues

- strongloop/loopback-cli#43

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)