### PR TITLE
Handle special char in API filename

### DIFF
--- a/soap/index.js
+++ b/soap/index.js
@@ -190,8 +190,11 @@ module.exports = yeoman.Base.extend({
     for (i = 0, n = self.apis.length; i < n; i++) {
       api = self.apis[i];
       // TODO [rashmi] use binding name for now
-      var basePath = this.bindingName;
-      var soapModel = 'soap_' + basePath.replace(/\//g, '_');
+      // basePath is used as file name for generated API file and top level API model file.
+      // Replace special characters in binding name with _ since these characters are not
+      // allowed in filename.
+      var basePath = this.bindingName.replace(/[-.\/`~!@#%^&*()-+={}'";:<>,?/]/g, '_');
+      var soapModel = 'soap_' + basePath;
       self.modelNames.push(soapModel);
       var modelDef = {
         name: soapModel,

--- a/test/soap.test.js
+++ b/test/soap.test.js
@@ -73,41 +73,8 @@ describe('loopback:soap tests', function() {
           done();
         });
       });
-
-    function givenModelGenerator(modelArgs) {
-      var path = '../../soap';
-      var name = 'loopback:soap';
-      var deps = [];
-      var gen = common.createGenerator(name, path, deps, modelArgs, {});
-      return gen;
-    }
-
-    function readModelJsonSync(name) {
-      var soapJson = path.resolve(SANDBOX, 'common/models/' + name + '.json');
-      expect(fs.existsSync(soapJson), 'file exists');
-      return JSON.parse(fs.readFileSync(soapJson));
-    }
-
-    function givenDataSourceGenerator(dsArgs) {
-      var path = '../../datasource';
-      var name = 'loopback:datasource';
-      var gen = common.createGenerator(name, path, [], dsArgs, {});
-      return gen;
-    }
-
-    function readModelConfigSync(facet) {
-      facet = facet || 'server';
-      var filepath = path.resolve(SANDBOX, facet, 'model-config.json');
-      var content = fs.readFileSync(filepath, 'utf-8');
-      return JSON.parse(content);
-    }
-
-    function readDataSourcesJsonSync(facet) {
-      var filepath = path.resolve(SANDBOX, facet || 'server', 'datasources.json'); // eslint-disable-line max-len
-      var content = fs.readFileSync(filepath, 'utf-8');
-      return JSON.parse(content);
-    }
   });
+
   describe('periodic table wsdl', function() {
     beforeEach(common.resetWorkspace);
 
@@ -178,39 +145,89 @@ describe('loopback:soap tests', function() {
           done();
         });
       });
-
-    function givenModelGenerator(modelArgs) {
-      var path = '../../soap';
-      var name = 'loopback:soap';
-      var deps = [];
-      var gen = common.createGenerator(name, path, deps, modelArgs, {});
-      return gen;
-    }
-
-    function readModelJsonSync(name) {
-      var soapJson = path.resolve(SANDBOX, 'common/models/' + name + '.json');
-      expect(fs.existsSync(soapJson), 'file exists');
-      return JSON.parse(fs.readFileSync(soapJson));
-    }
-
-    function givenDataSourceGenerator(dsArgs) {
-      var path = '../../datasource';
-      var name = 'loopback:datasource';
-      var gen = common.createGenerator(name, path, [], dsArgs, {});
-      return gen;
-    }
-
-    function readModelConfigSync(facet) {
-      facet = facet || 'server';
-      var filepath = path.resolve(SANDBOX, facet, 'model-config.json');
-      var content = fs.readFileSync(filepath, 'utf-8');
-      return JSON.parse(content);
-    }
-
-    function readDataSourcesJsonSync(facet) {
-      var filepath = path.resolve(SANDBOX, facet || 'server', 'datasources.json'); // eslint-disable-line max-len
-      var content = fs.readFileSync(filepath, 'utf-8');
-      return JSON.parse(content);
-    }
   });
+
+  describe('binding with special character', function() {
+    beforeEach(common.resetWorkspace);
+    beforeEach(function createSandbox(done) {
+      helpers.testDirectory(SANDBOX, done);
+    });
+    beforeEach(function createProject(done) {
+      common.createDummyProject(SANDBOX, 'test-soapapp', done);
+    });
+    beforeEach(function createDataSource(done) {
+      var modelGen = givenDataSourceGenerator();
+      helpers.mockPrompt(modelGen, {
+        name: 'soapds',
+        customConnector: '', // temporary workaround for
+                             // https://github.com/yeoman/generator/issues/600
+        connector: 'soap',
+        url: 'http://localhost:15099/rpc_Literal_testing',
+        wsdl: path.join(__dirname, 'soap/special_char_test.wsdl'),
+        remotingEnabled: true,
+        installConnector: false,
+      });
+      modelGen.run(function() {
+        done();
+      });
+    });
+
+    it('API file name test',
+      function(done) {
+        var modelGen = givenModelGenerator();
+        helpers.mockPrompt(modelGen, {
+          dataSource: 'soapds',
+          service: 'RPCLiteralService',
+          binding: 'RPCLiteralTest2.0Binding',
+          operations: ['myMethod'],
+        });
+
+        // this runs command  loopback:soap command with mock up /test/soap/stockquote.wsdl as input from command prompt
+        modelGen.run(function() {
+          var content = readAPIFileSync('soap-rpc-literal-test-2-0-binding');
+          done();
+        });
+      });
+  });
+
+  function readAPIFileSync(name) {
+    var soapAPIJson = path.resolve(SANDBOX, 'server/models/' + name + '.json');
+    expect(fs.existsSync(soapAPIJson)).to.equal(true);
+    var soapAPIModel = path.resolve(SANDBOX, 'server/models/' + name + '.js');
+    expect(fs.existsSync(soapAPIModel)).to.equal(true);
+  }
+
+  function givenModelGenerator(modelArgs) {
+    var path = '../../soap';
+    var name = 'loopback:soap';
+    var deps = [];
+    var gen = common.createGenerator(name, path, deps, modelArgs, {});
+    return gen;
+  }
+
+  function readModelJsonSync(name) {
+    var soapJson = path.resolve(SANDBOX, 'common/models/' + name + '.json');
+    expect(fs.existsSync(soapJson)).to.equal(true);
+    return JSON.parse(fs.readFileSync(soapJson));
+  }
+
+  function givenDataSourceGenerator(dsArgs) {
+    var path = '../../datasource';
+    var name = 'loopback:datasource';
+    var gen = common.createGenerator(name, path, [], dsArgs, {});
+    return gen;
+  }
+
+  function readModelConfigSync(facet) {
+    facet = facet || 'server';
+    var filepath = path.resolve(SANDBOX, facet, 'model-config.json');
+    var content = fs.readFileSync(filepath, 'utf-8');
+    return JSON.parse(content);
+  }
+
+  function readDataSourcesJsonSync(facet) {
+    var filepath = path.resolve(SANDBOX, facet || 'server', 'datasources.json'); // eslint-disable-line max-len
+    var content = fs.readFileSync(filepath, 'utf-8');
+    return JSON.parse(content);
+  }
 });

--- a/test/soap/special_char_test.wsdl
+++ b/test/soap/special_char_test.wsdl
@@ -1,0 +1,44 @@
+<?xml version="1.0"?>
+
+<!-- rpc/Literal example -->
+
+<wsdl:definitions name="StockQuoteRPCLiteral"
+                  targetNamespace="http://example.com/rpc_Literal_test.wsdl"
+                  xmlns:tns="http://example.com/rpc_literal_test.wsdl"
+                  xmlns:xsd1="http://example.com/rpc_literal_test.xsd"
+                  xmlns:soap="http://schemas.xmlsoap.org/wsdl/soap/"
+                  xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/"
+                  xmlns:xsd="http://www.w3.org/2000/10/XMLSchema">
+
+    <wsdl:message name="myMethodRequest">
+        <wsdl:part name="x" type="xsd:int"/>
+        <wsdl:part name="y" type="xsd:float"/>
+    </wsdl:message>
+
+
+    <wsdl:portType name="RPCLiteralTest">
+        <wsdl:operation name="myMethod">
+            <wsdl:input message="tns:myMethodRequest"/>
+        </wsdl:operation>
+    </wsdl:portType>
+
+
+    <wsdl:binding name="RPCLiteralTest2.0Binding" type="tns:RPCLiteralTest">
+        <soap:binding style="rpc"
+                      transport="http://schemas.xmlsoap.org/soap/http"/>
+        <wsdl:operation name="myMethod">
+            <soap:operation soapAction="http://example.com/RPCLiteralTest"/>
+            <wsdl:input>
+                <soap:body/>
+            </wsdl:input>
+        </wsdl:operation>
+    </wsdl:binding>
+
+    <wsdl:service name="RPCLiteralService">
+        <wsdl:port name="RpcLiteralTestPort" binding="tns:RPCLiteralTest2.0Binding">
+            <soap:address location="http://localhost:15099/rpc_Literal_testing"/>
+        </wsdl:port>
+    </wsdl:service>
+
+</wsdl:definitions>
+


### PR DESCRIPTION
There are 2 bugs in this issue https://github.com/strongloop/loopback-connector-soap/issues/78 
and the first issue is fixed in this PR https://github.com/strongloop/loopback-soap/pull/7.  2nd issue is fixed with this current PR. We use binding name as top level REST API file/model filename and if special characters are present (e.g '.') which are not acceptable in filename, then, code generation fails with exception as reported in issue https://github.com/strongloop/loopback-connector-soap/issues/78 . This PR replaces special characters with underscore '_' . Also added test to cover this use case and cleaned up/refactored test code.
@raymondfeng PTAL