### PR TITLE
Bind service to app conditionally

### DIFF
--- a/datasource/index.js
+++ b/datasource/index.js
@@ -32,6 +32,7 @@ module.exports = yeoman.Base.extend({
   constructor: function() {
     yeoman.Base.apply(this, arguments);
     this.abort = false;
+    this.serviceBindingStatus = 'unbound';
     this.option('bluemix', {
       desc: g.f('Add a datasource from Bluemix'),
     });
@@ -152,8 +153,11 @@ module.exports = yeoman.Base.extend({
   },
 
   bindServiceToApp: function() {
+    if (this.abort) return;
     if (this.options.bluemix) {
+      this.serviceBindingStatus = 'binding';
       ds.bindServiceToApp(this);
+      this.serviceBindingStatus = 'bound';
     }
   },
 

--- a/test/datasource.test.js
+++ b/test/datasource.test.js
@@ -204,6 +204,43 @@ describe('loopback:datasource generator', function() {
       });
 
       // this test requires an IBM Object Storage service named "My-Object-Storage" to be provisioned already
+      it('should not try to bind a service despite error', function(done) {
+        var appGen = givenAppGenerator();
+
+        helpers.mockPrompt(appGen, {
+          appname: 'test-app',
+          template: 'api-server',
+          appMemory: '512M',
+          appInstances: 1,
+          appDomain: 'mybluemix.net',
+          appHost: 'test-app',
+          appDiskQuota: '512M',
+          enableDocker: true,
+          enableToolchain: true,
+          enableAutoScaling: true,
+          enableAppMetrics: true,
+        });
+
+        appGen.options['skip-install'] = true;
+        appGen.options['bluemix'] = true;
+        appGen.options['login'] = false;
+
+        appGen.run(function() {
+          var datasourceGen = givenDataSourceGenerator('--bluemix', '../../../datasource');
+          datasourceGen.abort = true;
+          helpers.mockPrompt(datasourceGen, {
+            serviceName: 'My-Object-Storage',
+            connector: 'loopback-component-storage',
+            installConnector: false,
+          });
+          datasourceGen.run(function() {
+            expect(datasourceGen.serviceBindingStatus).to.equal('unbound');
+            done();
+          });
+        });
+      });
+
+      // this test requires an IBM Object Storage service named "My-Object-Storage" to be provisioned already
       it('should support IBM Object Storage ', function(done) {
         var appGen = givenAppGenerator();
 


### PR DESCRIPTION
### Description

Fixes a bug which caused `datasource` command to try to bind a data source despite errors.

#### Related issues

<!--
Please use the following link syntaxes:

- #49 (to reference issues in the current repository)
- strongloop/loopback#49 (to reference issues in another repository)
-->

- None

### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
