### PR TITLE
Fix export-api-def hanging if project contains ongoing async operations

### DIFF
--- a/export-api-def/index.js
+++ b/export-api-def/index.js
@@ -45,5 +45,8 @@ module.exports = yeoman.Base.extend({
     } else {
       process.stdout.write(apiDef);
     }
+
+    // Kill app if still alive
+    setTimeout(process.exit, 100);
   },
 });

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "mocha": "^3.2.0",
     "rimraf": "^2.6.1",
     "semver": "^5.1.0",
+    "sinon": "^3.2.1",
     "strong-cached-install": "^2.0.0",
     "yeoman-assert": "^2.2.1",
     "yeoman-test": "^1.4.0"


### PR DESCRIPTION
### Description
If the command `export-api-def` is ran on an app that has ongoing async calls and never returns, the loopback generator itself never returns, waiting for module to finish loading.

This fix exits the Node process as soon as swagger spec has been written

WIP because for now I'm not sure how to test this fix. 

#### Related issues

- strongloop/loopback-cli/issues/50


### Checklist

<!--
Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
-->

- [ ] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
