### PR TITLE
Improve $ref support for swagger objects

### DIFF
--- a/package.json
+++ b/package.json
@@ -44,6 +44,7 @@
     "request": "^2.60.0",
     "strong-globalize": "^2.6.8",
     "strong-soap": "^1.2.2",
+    "swagger-parser": "^4.0.1",
     "text-table": "^0.2.0",
     "yaml-js": "^0.1.4",
     "yeoman-generator": "^0.24.1"

--- a/test/swagger/pet-store-1.2.json
+++ b/test/swagger/pet-store-1.2.json
@@ -45,7 +45,7 @@
         "notes": "",
         "type": "array",
         "items": {
-          "$ref": "Pet"
+          "$ref": "#/models/Pet"
         },
         "nickname": "partialUpdate",
         "produces": ["application/json", "application/xml"],
@@ -242,7 +242,7 @@
         "notes": "Multiple status values can be provided with comma seperated strings",
         "type": "array",
         "items": {
-          "$ref": "Pet"
+          "$ref": "#/models/Pet"
         },
         "nickname": "findPetsByStatus",
         "authorizations": {},
@@ -276,7 +276,7 @@
         "notes": "Muliple tags can be provided with comma seperated strings. Use tag1, tag2, tag3 for testing.",
         "type": "array",
         "items": {
-          "$ref": "Pet"
+          "$ref": "#/models/Pet"
         },
         "nickname": "findPetsByTags",
         "authorizations": {},
@@ -368,7 +368,7 @@
         "maximum": "100.0"
       },
       "category": {
-        "$ref": "Category"
+        "$ref": "#/models/Category"
       },
       "name": {
         "type": "string"
@@ -382,7 +382,7 @@
       "tags": {
         "type": "array",
         "items": {
-          "$ref": "Tag"
+          "$ref": "#/models/Tag"
         }
       },
       "status": {

--- a/test/swagger/pet-store-2.0.json
+++ b/test/swagger/pet-store-2.0.json
@@ -440,12 +440,7 @@
       "produces": ["application/json", "application/xml"],
       "parameters": [
         {
-          "in": "path",
-          "name": "petId",
-          "description": "ID of pet that needs to be fetched",
-          "required": true,
-          "type": "integer",
-          "format": "int64"
+          "$ref": "#/parameters/petId"
         }
       ],
       "responses": {
@@ -463,6 +458,15 @@
         }
       }
     }
+  }
+}, "parameters": {
+  "petId": {
+    "in": "path",
+    "name": "petId",
+    "description": "ID of pet that needs to be fetched",
+    "required": true,
+    "type": "integer",
+    "format": "int64"
   }
 }, "definitions": {
   "Customer": {
@@ -513,7 +517,7 @@
       "tags": {
         "type": "array",
         "items": {
-          "$ref": "Tag"
+          "$ref": "#/definitions/Tag"
         }
       },
       "photoUrls": {
@@ -523,7 +527,7 @@
         }
       },
       "category": {
-        "$ref": "Category"
+        "$ref": "#/definitions/Category"
       },
       "id": {
         "type": "integer",

--- a/test/swagger/pet-store-2.0.yml
+++ b/test/swagger/pet-store-2.0.yml
@@ -432,13 +432,13 @@ definitions:
       tags:
         type: "array"
         items:
-          $ref: "Tag"
+          $ref: "#/definitions/Tag"
       photoUrls:
         type: "array"
         items:
           type: "string"
       category:
-        $ref: "Category"
+        $ref: "#/definitions/Category"
       id:
         type: "integer"
         format: "int64"


### PR DESCRIPTION
### Description

The PR use `swagger-parser` to resolve `$ref` for Swagger 2.0 docs.

Depends on https://github.com/strongloop/loopback-swagger/pull/114

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
