### PR TITLE
feat: Allow appName to be passed in as options

### DIFF
--- a/bluemix/helpers.js
+++ b/bluemix/helpers.js
@@ -51,7 +51,7 @@ bluemix.configurePrompt = function() {
   if (this.done) return;
   // https://github.com/strongloop/generator-loopback/issues/38
   // yeoman-generator normalize the appname with ' '
-  this.appName = path.basename(process.cwd())
+  this.appName = this.options.appName || path.basename(process.cwd())
                 .replace(/[\/@\s\+%:\.]+?/g, '-');
 
   // Generate .bluemix/...

--- a/bluemix/index.js
+++ b/bluemix/index.js
@@ -26,7 +26,7 @@ module.exports = yeoman.Base.extend({
 
     this.option('appName', {
       desc: g.f('Application name'),
-      type: String
+      type: String,
     });
 
     this.option('docker', {

--- a/bluemix/index.js
+++ b/bluemix/index.js
@@ -23,6 +23,12 @@ module.exports = yeoman.Base.extend({
   constructor: function() {
     yeoman.Base.apply(this, arguments);
     this.done = false;
+
+    this.option('appName', {
+      desc: g.f('Application name'),
+      type: String
+    });
+
     this.option('docker', {
       desc: g.f('Generate Dockerfile'),
       type: Boolean,

--- a/test/fixtures/help-texts/loopback_bluemix_help.txt
+++ b/test/fixtures/help-texts/loopback_bluemix_help.txt
@@ -5,6 +5,7 @@ Options:
   -h,   --help          # Print the generator's options and usage
         --skip-cache    # Do not remember prompt answers             Default: false
         --skip-install  # Do not automatically install dependencies  Default: false
+        --appName       # Application name
         --docker        # Generate Dockerfile
         --manifest      # Generate Bluemix manifest file
         --toolchain     # Set up Bluemix toolchain


### PR DESCRIPTION
### Description
Allow appName to be passed as an option for automated (non-prompted) usage.


#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [ ] New tests added or existing tests modified to cover all changes
- [ ] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
