### PR TITLE
docs: update links from docs.strongloop.com

### DIFF
--- a/boot-script/templates/async.js
+++ b/boot-script/templates/async.js
@@ -5,7 +5,7 @@ module.exports = function(app, cb) {
    * The `app` object provides access to a variety of LoopBack resources such as
    * models (e.g. `app.models.YourModelName`) or data sources (e.g.
    * `app.datasources.YourDataSource`). See
-   * http://docs.strongloop.com/display/public/LB/Working+with+LoopBack+objects
+   * https://loopback.io/doc/en/lb3/Working-with-LoopBack-objects.html
    * for more info.
    */
   process.nextTick(cb); // Remove if you pass `cb` to an async function yourself

--- a/boot-script/templates/sync.js
+++ b/boot-script/templates/sync.js
@@ -5,7 +5,7 @@ module.exports = function(app) {
    * The `app` object provides access to a variety of LoopBack resources such as
    * models (e.g. `app.models.YourModelName`) or data sources (e.g.
    * `app.datasources.YourDataSource`). See
-   * http://docs.strongloop.com/display/public/LB/Working+with+LoopBack+objects
+   * https://loopback.io/doc/en/lb3/Working-with-LoopBack-objects.html
    * for more info.
    */
 };

--- a/swagger/README.md
+++ b/swagger/README.md
@@ -2,38 +2,38 @@
 
 ## What is LoopBack?
 
-[LoopBack](http://loopback.io) is an open source Node.js API framework from 
-[StrongLoop](http://www.strongloop.com). It is built on top of Express 
-optimized for mobile, web, and other devices. LoopBack makes it really easy 
-and productive for developers to define, build and consume APIs. Define data 
-models, connect to multiple data sources, write business logic in Node.js, 
-glue on top of your existing services and data, and consume using JS, iOS & 
+[LoopBack](http://loopback.io) is an open source Node.js API framework from
+[StrongLoop](http://www.strongloop.com). It is built on top of Express
+optimized for mobile, web, and other devices. LoopBack makes it really easy
+and productive for developers to define, build and consume APIs. Define data
+models, connect to multiple data sources, write business logic in Node.js,
+glue on top of your existing services and data, and consume using JS, iOS &
 Android SDKs.
 
 ## What is Swagger?
 
-[Swagger](https://github.com/reverb/swagger-spec) defines a standard, 
-language-agnostic interface to REST APIs which allows both humans and computers 
-to discover and understand the capabilities of the service without access to 
+[Swagger](https://github.com/reverb/swagger-spec) defines a standard,
+language-agnostic interface to REST APIs which allows both humans and computers
+to discover and understand the capabilities of the service without access to
 source code, documentation, or through network traffic inspection.
 
 ## LoopBack + Swagger = API business
 
 ![loopback swagger](images/loopback-swagger-integration.png)
 
-LoopBack comes with a Swagger based API explorer since day one to provide 
-instant visibility for REST APIs exposed by LoopBack models. So far with 
+LoopBack comes with a Swagger based API explorer since day one to provide
+instant visibility for REST APIs exposed by LoopBack models. So far with
 LoopBack, most developers define models and implement the API logic in Node.js.
 The JavaScript methods are annotated with remoting metadata so that they can be
-exposed as REST APIs. LoopBack publishes such definitions as Swagger specs in 
-JSON format. The API explorer creates an API playground based on the specs. 
+exposed as REST APIs. LoopBack publishes such definitions as Swagger specs in
+JSON format. The API explorer creates an API playground based on the specs.
 
 What about starting with an API design spec? API consumers and providers often
 want to discuss, understand, and agree on the APIs as the contract first before
 building code for either side. To support API design first approach, we're happy
 to announce the availability of loopback:swagger generator which can generate a
-fully-functional application that provide the apis conforming to the swagger 
-specification. 
+fully-functional application that provide the apis conforming to the swagger
+specification.
 
 ## Scaffolding a LoopBack application from swagger specs
 
@@ -42,7 +42,8 @@ Before we start, please make sure you have StrongLoop tools installed:
 ```sh
 npm install -g strongloop
 ```
-For more information, see http://docs.strongloop.com/display/LB/Getting+Started+with+LoopBack.
+
+For more information, see http://loopback.io/doc/en/lb3/Getting-started-with-LoopBack.html.
 
 ### Create a loopback application
 
@@ -62,6 +63,7 @@ Now let's try to generate apis from swagger specs.
 cd swagger-demo
 slc loopback:swagger
 ```
+
 When prompted, first provide a url to the swagger spec. In this demo, we use:
 
 https://raw.githubusercontent.com/reverb/swagger-spec/master/examples/v2.0/json/petstore-expanded.json
@@ -72,7 +74,6 @@ The generator loads the spec and discovers models and apis. It then prompts you
 to select from the list of models to be created.
 
 ![slc loopback:swagger](images/loopback-swagger-full.png)
-
 
 ### Check the project
 
@@ -97,6 +98,7 @@ Please note pet/newPet/errorModel models are now connected to the database selec
 ### Run the application
 
 To run the application:
+
 ```sh
 node .
 ```
@@ -130,7 +132,7 @@ module.exports = function(SwaggerApi) {
 
 /**
  * Returns all pets from the system that the user has access to
- * @param {array} tags tags to filter by 
+ * @param {array} tags tags to filter by
  * @param {integer} limit maximum number of results to return
  * @callback {Function} callback Callback function
  * @param {Error|String} err Error object
@@ -142,13 +144,13 @@ SwaggerApi.findPets = function (tags, limit, callback) {
     var err = new Error('Not implemented');
     callback(err);
   });
-  
+
 }
 ...
 SwaggerApi.remoteMethod('findPets',
   { isStatic: true,
   produces: [ 'application/json', 'application/xml', 'text/xml', 'text/html' ],
-  accepts: 
+  accepts:
    [ { arg: 'tags',
        type: [ 'string' ],
        description: 'tags to filter by',
@@ -159,7 +161,7 @@ SwaggerApi.remoteMethod('findPets',
        description: 'maximum number of results to return',
        required: false,
        http: { source: 'query' } } ],
-  returns: 
+  returns:
    [ { description: 'unexpected error',
        type: 'errorModel',
        arg: 'data',
@@ -173,53 +175,50 @@ Let's use the Pet model to implement the corresponding methods:
 
 ```js
 SwaggerApi.findPets = function(tags, limit, callback) {
-  var filter = {limit: limit};
+  var filter = { limit: limit };
   if (tags && tags.length) {
-    filter.where = {tag: {inq: tags}};
+    filter.where = { tag: { inq: tags } };
   }
   SwaggerApi.app.models.pet.find(filter, callback);
-}
+};
 
-SwaggerApi.addPet = function (pet, callback) {
+SwaggerApi.addPet = function(pet, callback) {
   SwaggerApi.app.models.pet.create(pet, callback);
-  
-}
+};
 
-SwaggerApi.findPetById = function (id, callback) {
+SwaggerApi.findPetById = function(id, callback) {
   SwaggerApi.app.models.pet.findById(id, callback);
-  
-}
+};
 
-SwaggerApi.deletePet = function (id, callback) {
+SwaggerApi.deletePet = function(id, callback) {
   SwaggerApi.app.models.pet.deleteById(id, callback);
-  
-}
+};
 ```
 
 Now you can restart the server and try again:
 
-1. Try `getPets`. You'll see an empty array coming back.
-2. Try `addPet` to post one or more records to create new pets.
-3. Try `getPets` again. You'll see the newly created pets.
-4. Try `findPetById`. You should be look up pets by id now.
-5. Try `deletePet`. Pets can be deleted by id.
+1.  Try `getPets`. You'll see an empty array coming back.
+2.  Try `addPet` to post one or more records to create new pets.
+3.  Try `getPets` again. You'll see the newly created pets.
+4.  Try `findPetById`. You should be look up pets by id now.
+5.  Try `deletePet`. Pets can be deleted by id.
 
 You can also use the `pet` model directly. It will provide you the full CRUD
 operations.
 
 ## Swagger versions
 
-The LoopBack swagger generator supports both [2.0](https://github.com/reverb/swagger-spec/blob/master/versions/2.0.md) 
-and [1.2](https://github.com/reverb/swagger-spec/blob/master/versions/1.2.md) versions. 
-Feel free to try it out with the pet store v1.2 spec at http://petstore.swagger.wordnik.com/api/api-docs. 
-Please note in 1.2, the spec URL can be the resource listing or a specific api 
+The LoopBack swagger generator supports both [2.0](https://github.com/reverb/swagger-spec/blob/master/versions/2.0.md)
+and [1.2](https://github.com/reverb/swagger-spec/blob/master/versions/1.2.md) versions.
+Feel free to try it out with the pet store v1.2 spec at http://petstore.swagger.wordnik.com/api/api-docs.
+Please note in 1.2, the spec URL can be the resource listing or a specific api
 specification. For resource listing, all api specifications will be automatically
-fetched and processed. 
-
+fetched and processed.
 
 ## Summary
 
-With the swagger generator, we now have the complete round trip: 
+With the swagger generator, we now have the complete round trip:
+
 - Start with a swagger spec
 - Generate corresponding models and methods for your application
 - Implement the remote methods


### PR DESCRIPTION
> There are links to docs.strongloop.com in various places in the code that we should replace with links to the new doc site loopback.io/doc

There are 3 links that are fixed in this PR, and the rests are formatting changes from running the linter:
- boot-script/templates/async.js
- boot-script/templates/sync.js
- swagger/README.md

connected to: https://github.com/strongloop-internal/scrum-loopback/issues/1108