### PR TITLE
Add --version to help options

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -60,6 +60,11 @@ module.exports = yeoman.Base.extend({
       desc: g.f('Set up as a Bluemix app'),
       type: Boolean,
     });
+
+    this.option('version', {
+      desc: g.f('Display version information'),
+      type: Boolean,
+    });
   },
 
   help: function() {

--- a/app/index.js
+++ b/app/index.js
@@ -61,10 +61,12 @@ module.exports = yeoman.Base.extend({
       type: Boolean,
     });
 
-    this.option('version', {
-      desc: g.f('Display version information'),
-      type: Boolean,
-    });
+    if (helpers.getCommandName() === 'loopback-cli') {
+      this.option('version', {
+        desc: g.f('Display version information'),
+        type: Boolean,
+      });
+    }
   },
 
   help: function() {


### PR DESCRIPTION
### Description

Add `--version` to the list of options when displaying help.

#### Related issues

- connect to strongloop/loopback-cli#35

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)