### PR TITLE
Fix the expected list of supported LB versions [5.x]

### DIFF
--- a/test/app.test.js
+++ b/test/app.test.js
@@ -214,7 +214,7 @@ describe('loopback:app generator', function() {
       gen.run(function(err) {
         expect(err.message).to.eql(
           'Invalid LoopBack version: invalid-version. ' +
-          'Available versions are 2.x, 3.x.'
+          'Available versions are 3.x, 2.x.'
         );
 
         // a way to get around Workspace.copyRecursive not being properly


### PR DESCRIPTION
Change the order from [2.x, 3.x] to [3.x, 2.x] to match the actual
behavior.

This is a partial back-port of #399

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
