### PR TITLE
Use options from datasource to connect and get wsdl

### DIFF
--- a/soap/index.js
+++ b/soap/index.js
@@ -4,7 +4,6 @@
 // License text available at https://opensource.org/licenses/MIT
 
 'use strict';
-
 var g = require('../lib/globalize');
 var chalk = require('chalk');
 var yeoman = require('yeoman-generator');
@@ -107,6 +106,7 @@ module.exports = class SoapGenerator extends ActionsMixin(yeoman) {
         }
       }
       self.url = self.selectedDS.data.wsdl;
+      self.options = self.selectedDS.data;
       self.log(chalk.green(g.f('WSDL for datasource %s: %s',
         this.selectedDSName, self.url)));
     }.bind(this));
@@ -116,19 +116,20 @@ module.exports = class SoapGenerator extends ActionsMixin(yeoman) {
   soap() {
     var self = this;
     var done = this.async();
-    generator.getServices(this.url, this.log, function(err, services) {
-      if (err) {
-        done(err);
-      } else {
-        self.services = services;
-        var serviceNames = [];
-        for (var s in services) {
-          serviceNames.push(services[s].$name);
+    generator.getServices(this.url, this.options, this.log,
+      function(err, services) {
+        if (err) {
+          done(err);
+        } else {
+          self.services = services;
+          var serviceNames = [];
+          for (var s in services) {
+            serviceNames.push(services[s].$name);
+          }
+          self.serviceNames = serviceNames;
+          done();
         }
-        self.serviceNames = serviceNames;
-        done();
-      }
-    });
+      });
   }
 
   askForService() {

--- a/soap/wsdl-loader.js
+++ b/soap/wsdl-loader.js
@@ -18,8 +18,8 @@ var selectedWsdl, selectedWsdlUrl, wsdlServices,
   selectedService, selectedBinding;
 
 // loads remote WSDL or local WSDL using strong-soap module APIs.
-function loadWsdl(wsdlUrl, log, cb) {
-  WSDL.open(wsdlUrl, {}, function(err, wsdl) {
+function loadWsdl(wsdlUrl, options, log, cb) {
+  WSDL.open(wsdlUrl, options, function(err, wsdl) {
     if (err) {
       return cb(err);
     }
@@ -28,8 +28,8 @@ function loadWsdl(wsdlUrl, log, cb) {
 }
 
 // get services defined in the wsdl
-exports.getServices = function getServices(wsdlUrl, log, cb) {
-  loadWsdl(wsdlUrl, log, function(err, wsdl) {
+exports.getServices = function getServices(wsdlUrl, options, log, cb) {
+  loadWsdl(wsdlUrl, options, log, function(err, wsdl) {
     if (err) {
       return cb(err);
     }


### PR DESCRIPTION
### Description

Use options from datasource to connect and get wsdl. For example, It uses for sending http auth header.

#### Related issues

- connect to https://github.com/strongloop/loopback-connector-soap/issues/92

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
