### PR TITLE
Fix tests after removing 2.x in workspace

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -48,11 +48,6 @@ module.exports = class AppGenerator extends ActionsMixin(yeoman) {
       type: Boolean,
     });
 
-    this.option('loopbackVersion', {
-      desc: g.f('Select the LoopBack version'),
-      type: String,
-    });
-
     this.option('template', {
       desc: g.f('Set up the LoopBack application template'),
       type: String,

--- a/package.json
+++ b/package.json
@@ -36,7 +36,7 @@
     "loopback-bluemix": "^3.0.0",
     "loopback-soap": "^1.0.0",
     "loopback-swagger": "^5.4.0",
-    "loopback-workspace": "^4.0.0",
+    "loopback-workspace": "^5.0.0",
     "mkdirp": "^0.5.1",
     "opn": "^5.3.0",
     "ora": "^1.3.0",

--- a/test/app.test.js
+++ b/test/app.test.js
@@ -224,7 +224,7 @@ describe('loopback:app generator', function() {
         }).catch(function(err) {
           expect(err.message).to.eql(
             'Invalid LoopBack version: invalid-version. ' +
-            'Available versions are 3.x, 2.x.'
+            'Available versions are 3.x.'
           );
           ctx.generator.emit('end');
         });
@@ -247,23 +247,6 @@ describe('loopback:app generator', function() {
             'are api-server, empty-server, hello-world, notes'
           );
           ctx.generator.emit('end');
-        });
-    });
-
-  it('scaffolds 2.x app when option.loopbackVersion is 2.x',
-    function() {
-      return helpers.run(path.join(__dirname, '../app'))
-        .cd(SANDBOX)
-        .withPrompts({
-          name: 'test-app',
-          template: 'api-server',
-          loopbackVersion: '2.x',
-        })
-        .then(function() {
-          // generator calls `chdir` on change of the destination root
-          process.chdir(SANDBOX);
-          var pkg = common.readJsonSync('package.json', {});
-          expect(semver.gtr('3.0.0', pkg.dependencies.loopback)).to.equal(true);
         });
     });
 

--- a/test/fixtures/help-texts/loopback_app_help.txt
+++ b/test/fixtures/help-texts/loopback_app_help.txt
@@ -8,7 +8,6 @@ Options:
         --force-install    # Fail on install dependencies error                      Default: false
         --skip-next-steps  # Do not print "next steps" info
         --explorer         # Add Loopback Explorer to the project (true by default)
-        --loopbackVersion  # Select the LoopBack version
         --template         # Set up the LoopBack application template
         --bluemix          # Set up as a Bluemix app
 

--- a/test/remote-method.test.js
+++ b/test/remote-method.test.js
@@ -52,7 +52,6 @@ describe('loopback:remote-method generator', function() {
         var methods = definition.methods || {};
         expect(methods).to.have.property('myRemote');
         expect(methods.myRemote).to.eql({
-          isStatic: true,
           accepts: [],
           returns: [],
           http: [],
@@ -60,7 +59,7 @@ describe('loopback:remote-method generator', function() {
       });
   });
 
-  it('method name with `prototype.` should be removed', function() {
+  it('method name with `prototype.` should not be removed', function() {
     return helpers.run(path.join(__dirname, '../remote-method'))
       .cd(SANDBOX)
       .withPrompts({
@@ -74,10 +73,8 @@ describe('loopback:remote-method generator', function() {
       }).then(function() {
         var definition = common.readJsonSync('common/models/car.json');
         var methods = definition.methods || {};
-        expect(methods).to.have.property('myRemote');
-        expect(methods).to.not.have.property('prototype.myRemote');
-        expect(methods.myRemote).to.eql({
-          isStatic: false,
+        expect(methods).to.have.property('prototype.myRemote');
+        expect(methods['prototype.myRemote']).to.eql({
           accepts: [],
           returns: [],
           http: [],


### PR DESCRIPTION
### Description
After the PR https://github.com/strongloop/loopback-workspace/pull/549 to remove LB2.x version in the loopback-workspace, there are a few tests failure.  

The major changes are in the `remote-method.test.js`.  Following what @bajtos provided in this comment https://github.com/strongloop/loopback-workspace/pull/549#issuecomment-489141430, I've made the changes in this repo accordingly. 

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- https://github.com/strongloop/loopback-workspace/pull/549
- https://github.com/strongloop/loopback/issues/4180

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
