### PR TITLE
fix: honor the argument

### DIFF
--- a/boot-script/index.js
+++ b/boot-script/index.js
@@ -5,6 +5,7 @@
 
 'use strict';
 
+var debug = require('debug')('loopback:generator:boot-script');
 var g = require('../lib/globalize');
 var helpers = require('../lib/helpers');
 var helpText = require('../lib/help');
@@ -33,8 +34,11 @@ module.exports = class BootScriptGenerator extends ActionsMixin(yeoman) {
 
   askForName() {
     var done = this.async();
-
-    if (this.name) return done();
+    if (this.arguments && this.arguments.length >= 1) {
+      debug('boot-script name is provided as %s', this.arguments[0]);
+      this.name = this.arguments[0];
+      return done();
+    }
 
     var question = {
       name: 'name',

--- a/swagger/index.js
+++ b/swagger/index.js
@@ -66,6 +66,11 @@ module.exports = class SwaggerGenerator extends ActionsMixin(yeoman) {
   }
 
   askForSpecUrlOrPath() {
+    if (this.arguments && this.arguments.length >= 1) {
+      debug('swagger file path is provided as %s', this.arguments[0]);
+      this.url = this.arguments[0];
+    }
+
     var prompts = [
       {
         name: 'url',

--- a/test/boot-script.test.js
+++ b/test/boot-script.test.js
@@ -56,4 +56,21 @@ describe('loopback:boot-script generator', function() {
         expect(targetContents).to.equal(srcContents);
       });
   });
+
+  it('honors the first argument as name', function() {
+    return helpers.run(path.join(__dirname, '../boot-script'))
+      .cd(SANDBOX)
+      .withArguments('boot-script-with-name')
+      .withPrompts({
+        type: 'async',
+      }).then(function() {
+        var target = path.resolve(SANDBOX, 'server/boot/boot-script-with-name.js');
+        expect(fs.existsSync(target), 'file exists');
+
+        var targetContents = fs.readFileSync(target, 'utf8');
+        var src = path.resolve(__dirname, '../boot-script/templates/async.js');
+        var srcContents = fs.readFileSync(src, 'utf8');
+        expect(targetContents).to.equal(srcContents);
+      });
+  });
 });

--- a/test/swagger.test.js
+++ b/test/swagger.test.js
@@ -23,6 +23,36 @@ describe('loopback:swagger generator', function() {
     common.createDummyProject(SANDBOX, 'test-app', done);
   });
 
+  it('honors the first argument as url',
+    function() {
+      const url = path.join(__dirname, 'swagger/pet-store-2.0.json');
+      return helpers.run(path.join(__dirname, '../swagger'))
+        .cd(SANDBOX)
+        .withArguments([url])
+        .withPrompts({
+          modelSelections:
+          ['swagger_v2_petstore', 'Category',
+            'Pet', 'Tag', 'Order', 'Customer'],
+          dataSource: 'db',
+        }).then(function() {
+          var content = readModelJsonSync('pet');
+          expect(content).to.have.property('name', 'Pet');
+          expect(content).to.not.have.property('public');
+          expect(content).to.have.property('properties');
+          expect(content.properties).to.have.property('tags');
+          expect(content.properties).to.have.property('category');
+
+          expect(content.properties.tags.type).to.eql(['Tag']);
+          expect(content.properties.category.type).to.eql('Category');
+          expect(content.properties.photoUrls.type).to.eql(['string']);
+
+          var modelConfig = readModelConfigSync('server');
+          expect(modelConfig).to.have.property('Pet');
+          expect(modelConfig.Pet).to.have.property('public', false);
+          expect(modelConfig.Pet).to.have.property('dataSource', 'db');
+        });
+    });
+
   it('creates and configures Pet model from swagger 2.0 spec',
     function() {
       return helpers.run(path.join(__dirname, '../swagger'))


### PR DESCRIPTION
### Description

`lb swagger` and `lb boot-script` should honour the arguments.

Remove blocker for https://github.ibm.com/apimesh/apiconnect-cli-loopback/pull/132/

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to https://github.ibm.com/apimesh/apiconnect-cli-loopback/pull/132/

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
