### PR TITLE
fix: arguments for 2 commands

### DIFF
--- a/middleware/index.js
+++ b/middleware/index.js
@@ -5,13 +5,13 @@
 
 'use strict';
 
+var debug = require('debug')('loopback:generator:middleware');
 var g = require('../lib/globalize');
 var chalk = require('chalk');
 var yeoman = require('yeoman-generator');
 
 var wsModels = require('loopback-workspace').models;
 
-var actions = require('../lib/actions');
 var helpers = require('../lib/helpers');
 var helpText = require('../lib/help');
 var validateRequiredName = helpers.validateRequiredName;
@@ -74,6 +74,13 @@ module.exports = class MiddlewareGenerator extends ActionsMixin(yeoman) {
   }
 
   askForName() {
+    var done = this.async();
+    if (this.arguments && this.arguments.length >= 1) {
+      debug('middleware name is provided as %s', this.arguments[0]);
+      this.name = this.arguments[0];
+      return done();
+    }
+
     var prompts = [
       {
         name: 'name',
@@ -85,6 +92,7 @@ module.exports = class MiddlewareGenerator extends ActionsMixin(yeoman) {
 
     return this.prompt(prompts).then(function(props) {
       this.name = props.name;
+      done();
     }.bind(this));
   }
 

--- a/remote-method/index.js
+++ b/remote-method/index.js
@@ -58,31 +58,34 @@ module.exports = class RemoteMethodGenerator extends ActionsMixin(yeoman) {
   }
 
   askForModel() {
-    if (this.modelName) {
+    var done = this.async();
+    if (this.arguments && this.arguments.length >= 1) {
+      this.modelName = this.arguments[0];
       this.modelDefinition = this.projectModels.filter(function(m) {
         return m.name === this.modelName;
       }.bind(this))[0];
-
-      if (!this.modelDefinition) {
-        var msg = g.f('Model not found: %s' +
-                  '. Please choose from Model List:', this.modelName);
-        this.log(chalk.red(msg));
-      }
     }
 
-    if (!this.modelDefinition) {
-      var prompts = [
-        {
-          name: 'model',
-          message: g.f('Select the model:'),
-          type: 'list',
-          choices: this.editableModelNames,
-        },
-      ];
-      return this.prompt(prompts).then(function(answers) {
-        this.modelName = answers.model;
-      }.bind(this));
+    if (this.modelDefinition) {
+      return done();
     }
+
+    var msg = g.f('Model not found: %s' +
+    '. Please choose from Model List:', this.modelName);
+    this.log(chalk.red(msg));
+
+    var prompts = [
+      {
+        name: 'model',
+        message: g.f('Select the model:'),
+        type: 'list',
+        choices: this.editableModelNames,
+      },
+    ];
+    return this.prompt(prompts).then(function(answers) {
+      this.modelName = answers.model;
+      done();
+    }.bind(this));
   }
 
   findModelDefinition() {
@@ -98,7 +101,13 @@ module.exports = class RemoteMethodGenerator extends ActionsMixin(yeoman) {
   }
 
   askForParameters() {
-    var name = this.methodName;
+    var name;
+    if (this.arguments && this.arguments.length >= 2) {
+      debug('middleware name is provided as %s', this.arguments[1]);
+      // the method name
+      name = this.arguments[1];
+    }
+
     var prompts = [
       {
         name: 'methodName',

--- a/test/middleware.test.js
+++ b/test/middleware.test.js
@@ -97,6 +97,24 @@ describe('loopback:middleware generator', function() {
       });
   });
 
+  it('honors the first argument as middleware name', function() {
+    var builtinSources = Object.keys(readMiddlewaresJsonSync('server'));
+    return helpers.run(path.join(__dirname, '../middleware'))
+      .cd(SANDBOX)
+      .withArguments('my-middleware-with-name')
+      .withPrompts({
+        phase: 'my-phase-with-middleware-name',
+        paths: ['/x', '/y'],
+        params: '{"z": 1}',
+      }).then(function() {
+        var newSources = Object.keys(readMiddlewaresJsonSync('server'));
+        var expectedSources = builtinSources.concat(
+          ['my-phase-with-middleware-name']
+        );
+        expect(newSources).to.have.members(expectedSources);
+      });
+  });
+
   function givenMiddlewareGenerator(dsArgs) {
     var path = '../../middleware';
     var name = 'loopback:middleware';

--- a/test/remote-method.test.js
+++ b/test/remote-method.test.js
@@ -81,4 +81,26 @@ describe('loopback:remote-method generator', function() {
         });
       });
   });
+
+  it('honors the arguments as model and method names', function() {
+    return helpers.run(path.join(__dirname, '../remote-method'))
+      .cd(SANDBOX)
+      .withArguments(['Car', 'myRemote'])
+      .withPrompts({
+        isStatic: 'true',
+        desription: 'This is my remote method created with arguments',
+        httpPath: '',
+        acceptsArg: '',
+        returnsArg: '',
+      }).then(function() {
+        var definition = common.readJsonSync('common/models/car.json');
+        var methods = definition.methods || {};
+        expect(methods).to.have.property('myRemote');
+        expect(methods['myRemote']).to.eql({
+          accepts: [],
+          returns: [],
+          http: [],
+        });
+      });
+  });
 });


### PR DESCRIPTION
### Description

Similar to https://github.com/strongloop/generator-loopback/pull/408
Honor the arguments in the remote method and middleware commands.

#### Related issues

<!--
Please use the following link syntaxes:

- connect to #49 (to reference issues in the current repository)
- connect to strongloop/loopback#49 (to reference issues in another repository)
-->

- connect to <link_to_referenced_issue>

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
