### PR TITLE
move property name check to property generator

### DIFF
--- a/test/model.test.js
+++ b/test/model.test.js
@@ -18,6 +18,7 @@ var workspace = require('loopback-workspace');
 var Workspace = workspace.models.Workspace;
 
 describe('loopback:model generator', function() {
+  process.env.LB_CLI_SKIP_PROPERTY = true;
   beforeEach(common.resetWorkspace);
 
   beforeEach(function createSandbox(done) {
@@ -59,7 +60,6 @@ describe('loopback:model generator', function() {
         name: 'Product',
         dataSource: 'db',
         public: false,
-        propertyName: '',
       }).then(function() {
         var modelConfig = readModelsJsonSync('server');
         var newModels = Object.keys(modelConfig);


### PR DESCRIPTION
### Description

connect to https://github.ibm.com/apimesh/apiconnect-cli-loopback/issues/138

APIC cannot invoke the loop of property generator when run the model generator. 
In the previous implementation, invoking `.composeWith()` inside `.prompt()` cannot finish execution when `env.run()` takes in a cb function. For details please check the conversation in the related issue.

This PR moves the "property name prompt" and "empty property check" **from model generator to  property generator**, so that the composed generator won't be affected by `this.prompt()`.

*Test:* we don't test composed generator(actually there is no way to test it), so I manually verified the cli on local:

### loopback-cli

installed `loopback-cli` globally and npm link the `generator-loopback` inside it
```
(1) create a model with multiple properties

jannyhous-mbp:lb4app jannyhou$ lb model
? Enter the model name: Foo
? Select the datasource to attach Foo to: db (memory)
? Select model's base class PersistedModel
? Expose Foo via the REST API? Yes
? Custom plural form (used to build REST URL): 
? Common model or server only? common
Let's add some Foo properties now.

Enter an empty property name when done.
? Enter the property name: foo
? Property type: number
? Required? No
? Default value[leave blank for none]: 
property generator emits event finished
model generator receives event finished

Let's add another Foo property.
Enter an empty property name when done.
? Enter the property name: bar
? Property type: string
? Required? No
? Default value[leave blank for none]: 
property generator emits event finished
model generator receives event finished

Let's add another Foo property.
Enter an empty property name when done.
? Enter the property name: 
model generator receives event exitModelGenerator


(2) Add a model without property
jannyhou$ lb model
? Enter the model name: Bar
? Select the datasource to attach Bar to: db (memory)
? Select model's base class PersistedModel
? Expose Bar via the REST API? Yes
? Custom plural form (used to build REST URL): 
? Common model or server only? common
Let's add some Bar properties now.

Enter an empty property name when done.
? Enter the property name: 
model generator receives event exitModelGenerator


(3) add a property 
jannyhous-mbp:lb4app jannyhou$ lb property
? Select the model: Foo
? Enter the property name: baz
? Property type: boolean
? Required? No
? Default value[leave blank for none]: 
property generator emits event finished

(4) the property generator reports error when property name is empty
jannyhous-mbp:lb4app jannyhou$ lb property
? Select the model: Bar
? Enter the property name: 
>> Name is required

```

### apic

```
(1) add multiple properties when create model
jannyhous-mbp:test jannyhou$ apic create --type model
? Enter the model name: agoodmodel
? Select the data-source to attach agoodmodel to: db (memory)
? Select model's base class PersistedModel
? Expose agoodmodel via the REST API? Yes
? Custom plural form (used to build REST URL): 
? Common model or server only? common
Let's add some agoodmodel properties now.

Enter an empty property name when done.
? Property name: name
   invoke   loopback:property
? Property type: string
? Required? No
? Default value[leave blank for none]: 

Let's add another agoodmodel property.
Enter an empty property name when done.
? Property name: some
   invoke   loopback:property
? Property type: boolean
? Required? No
? Default value[leave blank for none]: 

Let's add another agoodmodel property.
Enter an empty property name when done.
? Property name: 
Done running LoopBack generator

Updating swagger and product definitions
Created /Users/jannyhou/apic-cli-property/test/definitions/test.yaml swagger description
jannyhous-mbp:test jannyhou$ 

(2) add property by `apic loopback:property`
jannyhous-mbp:test jannyhou$ apic loopback:property
? Select the model: agoodmodel
? Enter the property name: foo
? Property type: string
? Required? No
? Default value[leave blank for none]: 
Done running LoopBack generator

Updating swagger and product definitions
Created /Users/jannyhou/apic-cli-property/test/definitions/test.yaml swagger description

(3) `apic loopback:property` reports error when the property name is empty
Created /Users/jannyhou/apic-cli-property/test/definitions/test.yaml swagger description
jannyhous-mbp:test jannyhou$ apic loopback:property
? Select the model: agoodmodel
? Enter the property name: 
>> Name is required

```

### Checklist

<!--
- Please mark your choice with an "x" (i.e. [x], see
https://github.com/blog/1375-task-lists-in-gfm-issues-pulls-comments)
- PR's without test coverage will be closed.
-->

- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style
  guide](http://loopback.io/doc/en/contrib/style-guide.html)
