### PR TITLE
add tests for arrays in generation of soap models

### DIFF
--- a/package.json
+++ b/package.json
@@ -34,7 +34,7 @@
     "lodash": "^4.17.11",
     "loopback-api-definition": "^3.0.0",
     "loopback-bluemix": "^3.0.0",
-    "loopback-soap": "^1.0.0",
+    "loopback-soap": "^1.3.2",
     "loopback-swagger": "^5.4.0",
     "loopback-workspace": "^5.0.0",
     "mkdirp": "^0.5.1",

--- a/test/soap.test.js
+++ b/test/soap.test.js
@@ -1,4 +1,4 @@
-// Copyright IBM Corp. 2017,2019. All Rights Reserved.
+// Copyright IBM Corp. 2017,2020. All Rights Reserved.
 // Node module: generator-loopback
 // This file is licensed under the MIT License.
 // License text available at https://opensource.org/licenses/MIT
@@ -191,6 +191,134 @@ describe('loopback:soap tests', function() {
             operations: ['myMethod'],
           }).then(function() {
             var content = readAPIFileSync('soap-rpc-literal-test-2-0-binding');
+          });
+      });
+  });
+
+  describe('DataService wsdl with string array', function() {
+    beforeEach(common.resetWorkspace);
+    beforeEach(function createSandbox(done) {
+      helpers.testDirectory(SANDBOX, done);
+    });
+    beforeEach(function createProject(done) {
+      common.createDummyProject(SANDBOX, 'test-soapapp', done);
+    });
+    beforeEach(function createDataSource() {
+      return helpers.run(path.join(__dirname, '../datasource'))
+        .cd(SANDBOX)
+        .withPrompts({
+          name: 'ds',
+          connector: 'soap',
+          url: 'http://localhost:8080/DomSoap3/services/DataService',
+          wsdl: path.join(__dirname, 'soap/DataService_string_array.wsdl'),
+          remotingEnabled: true,
+          installConnector: false,
+        }).then();
+    });
+
+    it('DataService wsdl with string array',
+      function() {
+        return helpers.run(path.join(__dirname, '../soap'))
+          .cd(SANDBOX)
+          .withPrompts({
+            dataSource: 'ds',
+            service: 'DataServiceService',
+            binding: 'DataServiceSoapBinding',
+            operations: ['getSomeData'],
+          }).then(function() {
+            var content = readModelJsonSync('get-some-data');
+            expect(content).to.not.have.property('public');
+            expect(content).to.have.property('properties');
+            expect(content.properties.myParams.type).to.be.an('array');
+            expect(content.properties.myParams.type[0]).to.eql('string');
+
+            content = readModelJsonSync('some-data');
+            expect(content).to.not.have.property('public');
+            expect(content).to.have.property('properties');
+            expect(content.properties.integer_value.type).to.eql('number');
+            expect(content.properties.string_value.type).to.eql('string');
+            expect(content.properties.date_value.type).to.eql('string');
+
+            content = readModelJsonSync('get-some-data-response');
+            expect(content).to.not.have.property('public');
+            expect(content).to.have.property('properties');
+            expect(content.properties.getSomeDataReturn.type).to.be.an('array');
+            expect(content.properties.getSomeDataReturn.type[0]).
+              to.eql('SomeData');
+
+            var modelConfig = readModelConfigSync('server');
+            expect(modelConfig).to.have.property('SomeData');
+            expect(modelConfig.SomeData).to.have.property('public', true);
+            expect(modelConfig).to.have.property('getSomeData');
+            expect(modelConfig.getSomeData).to.have.property('public', true);
+            expect(modelConfig).to.have.property('getSomeDataResponse');
+            expect(modelConfig.getSomeDataResponse).
+              to.have.property('public', true);
+          });
+      });
+  });
+
+  describe('DataService wsdl with model array', function() {
+    beforeEach(common.resetWorkspace);
+    beforeEach(function createSandbox(done) {
+      helpers.testDirectory(SANDBOX, done);
+    });
+    beforeEach(function createProject(done) {
+      common.createDummyProject(SANDBOX, 'test-soapapp', done);
+    });
+    beforeEach(function createDataSource() {
+      return helpers.run(path.join(__dirname, '../datasource'))
+        .cd(SANDBOX)
+        .withPrompts({
+          name: 'ds',
+          connector: 'soap',
+          url: 'http://localhost:8080/DomSoap4/services/DataService',
+          wsdl: path.join(__dirname, 'soap/DataService_model_array.wsdl'),
+          remotingEnabled: true,
+          installConnector: false,
+        }).then();
+    });
+
+    it('DataService wsdl with model array',
+      function() {
+        return helpers.run(path.join(__dirname, '../soap'))
+          .cd(SANDBOX)
+          .withPrompts({
+            dataSource: 'ds',
+            service: 'DataServiceService',
+            binding: 'DataServiceSoapBinding',
+            operations: ['getSomeData'],
+          }).then(function() {
+            var content = readModelJsonSync('get-some-data');
+            expect(content).to.not.have.property('public');
+            expect(content).to.have.property('properties');
+            expect(content.properties.myParams.type).to.be.an('array');
+            expect(content.properties.myParams.type[0]).to.eql('SomeInputData');
+
+            content = readModelJsonSync('some-data');
+            expect(content).to.not.have.property('public');
+            expect(content).to.have.property('properties');
+            expect(content.properties.integer_value.type).to.eql('number');
+            expect(content.properties.string_value.type).to.eql('string');
+            expect(content.properties.date_value.type).to.eql('string');
+
+            content = readModelJsonSync('get-some-data-response');
+            expect(content).to.not.have.property('public');
+            expect(content).to.have.property('properties');
+            expect(content.properties.getSomeDataReturn.type).to.be.an('array');
+            expect(content.properties.getSomeDataReturn.type[0]).
+              to.eql('SomeData');
+
+            var modelConfig = readModelConfigSync('server');
+            expect(modelConfig).to.have.property('SomeData');
+            expect(modelConfig.SomeData).to.have.property('public', true);
+            expect(modelConfig).to.have.property('SomeInputData');
+            expect(modelConfig.SomeInputData).to.have.property('public', true);
+            expect(modelConfig).to.have.property('getSomeData');
+            expect(modelConfig.getSomeData).to.have.property('public', true);
+            expect(modelConfig).to.have.property('getSomeDataResponse');
+            expect(modelConfig.getSomeDataResponse).
+              to.have.property('public', true);
           });
       });
   });

--- a/test/soap.test.js
+++ b/test/soap.test.js
@@ -53,7 +53,7 @@ describe('loopback:soap tests', function() {
             content = readModelJsonSync('globals');
             expect(content).to.not.have.property('public');
             expect(content).to.have.property('properties');
-            expect(content.properties.Promise.type).to.eql('boolean');
+            expect(content.properties.EventEmitter.type).to.eql('boolean');
             expect(content.properties.Promise.type).to.eql('boolean');
 
             content = readModelJsonSync('get-quote-response');

--- a/test/soap/DataService_model_array.wsdl
+++ b/test/soap/DataService_model_array.wsdl
@@ -1,0 +1,66 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions targetNamespace="http://stuff.dom" xmlns:apachesoap="http://xml.apache.org/xml-soap" xmlns:impl="http://stuff.dom" xmlns:intf="http://stuff.dom" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsdlsoap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+ <wsdl:types>
+  <schema elementFormDefault="qualified" targetNamespace="http://stuff.dom" xmlns="http://www.w3.org/2001/XMLSchema">
+   <element name="getSomeData">
+    <complexType>
+     <sequence>
+      <element maxOccurs="unbounded" name="myParams" type="impl:SomeInputData"/>
+     </sequence>
+    </complexType>
+   </element>
+   <complexType name="SomeInputData">
+    <sequence>
+     <element name="search_value" nillable="true" type="xsd:string"/>
+    </sequence>
+   </complexType>
+   <element name="getSomeDataResponse">
+    <complexType>
+     <sequence>
+      <element maxOccurs="unbounded" name="getSomeDataReturn" type="impl:SomeData"/>
+     </sequence>
+    </complexType>
+   </element>
+   <complexType name="SomeData">
+    <sequence>
+     <element name="integer_value" type="xsd:int"/>
+     <element name="string_value" nillable="true" type="xsd:string"/>
+     <element name="date_value" nillable="true" type="xsd:string"/>
+    </sequence>
+   </complexType>
+  </schema>
+ </wsdl:types>
+   <wsdl:message name="getSomeDataRequest">
+      <wsdl:part element="impl:getSomeData" name="parameters">
+      </wsdl:part>
+   </wsdl:message>
+   <wsdl:message name="getSomeDataResponse">
+      <wsdl:part element="impl:getSomeDataResponse" name="parameters">
+      </wsdl:part>
+   </wsdl:message>
+   <wsdl:portType name="DataService">
+      <wsdl:operation name="getSomeData">
+         <wsdl:input message="impl:getSomeDataRequest" name="getSomeDataRequest">
+       </wsdl:input>
+         <wsdl:output message="impl:getSomeDataResponse" name="getSomeDataResponse">
+       </wsdl:output>
+      </wsdl:operation>
+   </wsdl:portType>
+   <wsdl:binding name="DataServiceSoapBinding" type="impl:DataService">
+      <wsdlsoap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+      <wsdl:operation name="getSomeData">
+         <wsdlsoap:operation soapAction=""/>
+         <wsdl:input name="getSomeDataRequest">
+            <wsdlsoap:body use="literal"/>
+         </wsdl:input>
+         <wsdl:output name="getSomeDataResponse">
+            <wsdlsoap:body use="literal"/>
+         </wsdl:output>
+      </wsdl:operation>
+   </wsdl:binding>
+   <wsdl:service name="DataServiceService">
+      <wsdl:port binding="impl:DataServiceSoapBinding" name="DataService">
+         <wsdlsoap:address location="http://localhost:8080/DomSoap4/services/DataService"/>
+      </wsdl:port>
+   </wsdl:service>
+</wsdl:definitions>

--- a/test/soap/DataService_string_array.wsdl
+++ b/test/soap/DataService_string_array.wsdl
@@ -1,0 +1,61 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<wsdl:definitions targetNamespace="http://stuff.dom" xmlns:apachesoap="http://xml.apache.org/xml-soap" xmlns:impl="http://stuff.dom" xmlns:intf="http://stuff.dom" xmlns:wsdl="http://schemas.xmlsoap.org/wsdl/" xmlns:wsdlsoap="http://schemas.xmlsoap.org/wsdl/soap/" xmlns:xsd="http://www.w3.org/2001/XMLSchema">
+ <wsdl:types>
+  <schema elementFormDefault="qualified" targetNamespace="http://stuff.dom" xmlns="http://www.w3.org/2001/XMLSchema">
+   <element name="getSomeData">
+    <complexType>
+     <sequence>
+      <element maxOccurs="unbounded" name="myParams" type="xsd:string"/>
+     </sequence>
+    </complexType>
+   </element>
+   <element name="getSomeDataResponse">
+    <complexType>
+     <sequence>
+      <element maxOccurs="unbounded" name="getSomeDataReturn" type="impl:SomeData"/>
+     </sequence>
+    </complexType>
+   </element>
+   <complexType name="SomeData">
+    <sequence>
+     <element name="integer_value" type="xsd:int"/>
+     <element name="string_value" nillable="true" type="xsd:string"/>
+     <element name="date_value" nillable="true" type="xsd:string"/>
+    </sequence>
+   </complexType>
+  </schema>
+ </wsdl:types>
+   <wsdl:message name="getSomeDataRequest">
+      <wsdl:part element="impl:getSomeData" name="parameters">
+      </wsdl:part>
+   </wsdl:message>
+   <wsdl:message name="getSomeDataResponse">
+      <wsdl:part element="impl:getSomeDataResponse" name="parameters">
+      </wsdl:part>
+   </wsdl:message>
+   <wsdl:portType name="DataService">
+      <wsdl:operation name="getSomeData">
+         <wsdl:input message="impl:getSomeDataRequest" name="getSomeDataRequest">
+       </wsdl:input>
+         <wsdl:output message="impl:getSomeDataResponse" name="getSomeDataResponse">
+       </wsdl:output>
+      </wsdl:operation>
+   </wsdl:portType>
+   <wsdl:binding name="DataServiceSoapBinding" type="impl:DataService">
+      <wsdlsoap:binding style="document" transport="http://schemas.xmlsoap.org/soap/http"/>
+      <wsdl:operation name="getSomeData">
+         <wsdlsoap:operation soapAction=""/>
+         <wsdl:input name="getSomeDataRequest">
+            <wsdlsoap:body use="literal"/>
+         </wsdl:input>
+         <wsdl:output name="getSomeDataResponse">
+            <wsdlsoap:body use="literal"/>
+         </wsdl:output>
+      </wsdl:operation>
+   </wsdl:binding>
+   <wsdl:service name="DataServiceService">
+      <wsdl:port binding="impl:DataServiceSoapBinding" name="DataService">
+         <wsdlsoap:address location="http://localhost:8080/DomSoap3/services/DataService"/>
+      </wsdl:port>
+   </wsdl:service>
+</wsdl:definitions>


### PR DESCRIPTION
Related to PR: https://github.com/strongloop/loopback-soap/pull/31 
Related to issue: https://github.com/strongloop/loopback-soap/issues/32

The tests for the generated API code are placed in `loopback-soap`.
The tests for the generated models are placed in `generator-loopback`.

My fix to issue https://github.com/strongloop/loopback-soap/issues/32 didn't involve arrays, but I was asked to make sure my fix in https://github.com/strongloop/loopback-soap/pull/31 could handle arrays.

Extra tests had to be added in this repository regarding models generated from WSDL files that have arrays in the operation input and/or output.
<!--
Please provide a high-level description of the changes made by your pull request.

Include references to all related GitHub issues and other pull requests, for example:

Fixes #123
Implements #254
See also #23
-->

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/generator-loopback) 👈

- [x] `npm test` passes on your machine
- [x] New tests added or existing tests modified to cover all changes
- [x] Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [ ] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
