### PR TITLE
Update dependencies (mkdirp, mocha)

### DIFF
--- a/package.json
+++ b/package.json
@@ -37,7 +37,7 @@
     "loopback-soap": "^1.3.2",
     "loopback-swagger": "^5.4.0",
     "loopback-workspace": "^5.0.0",
-    "mkdirp": "^0.5.1",
+    "mkdirp": "^1.0.4",
     "opn": "^5.3.0",
     "ora": "^1.3.0",
     "read-chunk": "^2.1.0",

--- a/package.json
+++ b/package.json
@@ -56,7 +56,7 @@
     "chai": "^3.2.0",
     "eslint": "^5.2.0",
     "eslint-config-loopback": "^11.0.0",
-    "mocha": "^5.2.0",
+    "mocha": "^7.1.2",
     "nock": "^9.0.14",
     "rimraf": "^2.6.1",
     "semver": "^5.1.0",


### PR DESCRIPTION
- deps: update mkdirp to ^1.0 to fix #416
- chore: update mocha to latest  - get rid of Prototype Pollution problem in minimist (see https://www.npmjs.com/advisories/1179)

Quoting from `mkdirp` release notes (see the full list of changes [here](https://github.com/isaacs/node-mkdirp/blob/master/CHANGELOG.md#10)):

> Drop support for outdated Node.js versions. (Technically still works on Node.js v8, but only 10 and above are officially supported.)

This package (`generator-loopback`) has `engines.node` set to `>=8`, but we officially don't support EOL version of Node.js and our tests are passing on Node.js 8.x with the new version of `mkdirp` too, so I guess this upgrade should be ok 🤞 

Also note that there are 25 more outdated dependencies, but considering that this package is in Maintenance LTS, it's probably better to not change things that are working fine.

## Checklist

👉 [Read and sign the CLA (Contributor License Agreement)](https://cla.strongloop.com/agreements/strongloop/generator-loopback) 👈

- [x] `npm test` passes on your machine
- New tests added or existing tests modified to cover all changes
- Code conforms with the [style guide](https://loopback.io/doc/en/contrib/style-guide-es6.html)
- [x] Commit messages are following our [guidelines](https://loopback.io/doc/en/contrib/git-commit-messages.html)
